### PR TITLE
Simple item smashing with an anvil

### DIFF
--- a/src/main/java/knightminer/inspirations/common/Config.java
+++ b/src/main/java/knightminer/inspirations/common/Config.java
@@ -1,5 +1,6 @@
 package knightminer.inspirations.common;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -645,9 +646,12 @@ public class Config {
 					.map(inputString -> {
 						if (inputString.contains(":")) {
 							ItemStack itemStack = RecipeUtil.getItemStackWithCountFromString(inputString);
-							return itemStack != null ? RecipeMatch.of(itemStack) : null;
+							return itemStack != null ? RecipeMatch.of(itemStack, itemStack.getCount(), 1) : null;
 						} else {
-							return RecipeMatch.of(inputString);
+							Iterator<String> it = Splitter.on("*").trimResults().split(inputString).iterator();
+							String oreDict = it.next();
+							Integer parsedCount = it.hasNext() ? Util.getInteger(it.next()) : null;
+							return RecipeMatch.of(oreDict, parsedCount != null ? parsedCount : 1, 1);
 						}
 					})
 					.collect(Collectors.toList());

--- a/src/main/java/knightminer/inspirations/common/Config.java
+++ b/src/main/java/knightminer/inspirations/common/Config.java
@@ -6,14 +6,13 @@ import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.common.base.Splitter;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 
 import knightminer.inspirations.Inspirations;
 import knightminer.inspirations.library.InspirationsRegistry;
+import knightminer.inspirations.library.Util;
 import knightminer.inspirations.library.recipe.anvil.AnvilItemSmashingRecipe;
 import knightminer.inspirations.library.recipe.anvil.CompositeRecipeMatch;
 import knightminer.inspirations.library.util.RecipeUtil;
@@ -645,7 +644,7 @@ public class Config {
 			List<RecipeMatch> inputStacks = Splitter.on(";").trimResults().splitToList(transformParts[0]).stream()
 					.map(inputString -> {
 						if (inputString.contains(":")) {
-							ItemStack itemStack = parseItemStackWithCount(inputString);
+							ItemStack itemStack = RecipeUtil.getItemStackWithCountFromString(inputString);
 							return itemStack != null ? RecipeMatch.of(itemStack) : null;
 						} else {
 							return RecipeMatch.of(inputString);
@@ -659,7 +658,7 @@ public class Config {
 
 			// output
 			List<ItemStack> outputStack = Splitter.on(";").trimResults().splitToList(transformParts[1]).stream()
-					.map(Config::parseItemStackWithCount).collect(Collectors.toList());
+					.map(RecipeUtil::getItemStackWithCountFromString).collect(Collectors.toList());
 			if(outputStack.isEmpty() || outputStack.stream().map(ItemStack::isEmpty).findAny().orElse(false)) {
 				Inspirations.log
 						.error("Invalid anvil item smashing {}: unable to parse output item stacks {}", transformation,
@@ -676,7 +675,7 @@ public class Config {
 				if(requirementParts.size() > 0) {
 					String heightString = requirementParts.get(0);
 					if(!heightString.isEmpty()) {
-						fallHeight = parseInteger(heightString);
+						fallHeight = Util.getInteger(heightString);
 						if(fallHeight == null) {
 							Inspirations.log
 									.error("Invalid anvil item smashing {}: unable to parse height requirement {}",
@@ -688,7 +687,7 @@ public class Config {
 				// block state
 				if(requirementParts.size() > 1) {
 					String stateString = requirementParts.get(1);
-					state = parseBlockstate(stateString);
+					state = RecipeUtil.getBlockstateFromString(stateString);
 					if(state == null) {
 						Inspirations.log.error("Invalid anvil item smashing {}: unable to parse block state requirement {}", transformation, stateString);
 						continue;
@@ -697,84 +696,9 @@ public class Config {
 			}
 
 			// register
-			InspirationsRegistry.addAnvilItemSmashingRecipe(new AnvilItemSmashingRecipe(CompositeRecipeMatch.ofMatches(inputStacks), ItemStackList.of(outputStack), state, fallHeight));
-		}
-	}
+			InspirationsRegistry.addAnvilItemSmashingRecipe(new AnvilItemSmashingRecipe(CompositeRecipeMatch.ofMatches(inputStacks), ItemStackList.of(outputStack),
 
-	/**
-	 * Parse a block state from a string with the format modid:name[:meta]
-	 * @param input input string
-	 * @return the block state or null if none could be found
-	 */
-	private static IBlockState parseBlockstate(String input) {
-		List<String> parts = Splitter.on(":").splitToList(input);
-		if(parts.size() < 2 || parts.size() > 3) {
-			return null;
-		}
-
-		// find block
-		String modId = parts.get(0);
-		String itemName = parts.get(1);
-		Block block = GameRegistry.findRegistry(Block.class).getValue(new ResourceLocation(modId, itemName));
-		if(block == null) {
-			return null;
-		}
-
-		// get actual state
-		if(parts.size() == 3) {
-			// parse meta
-			Integer meta = parseInteger(parts.get(2));
-			return meta != null && meta >= 0 ? block.getStateFromMeta(meta) : null;
-		} else {
-			// use default state
-			return block.getDefaultState();
-		}
-	}
-
-	/**
-	 * Transform a string with format mod:item[:meta][*count] into an item stack.
-	 * @param input input string
-	 * @return item stack, might be {@link ItemStack#EMPTY} if it cannot be parsed
-	 */
-	private static ItemStack parseItemStackWithCount(String input) {
-		// split off the item count
-		String[] parts = input.split("\\*");
-		if(parts.length == 0 || parts.length > 2) {
-			return ItemStack.EMPTY;
-		}
-
-		// transform the item stack part
-		ItemStack stack = RecipeUtil.getItemStackFromString(parts[0], false);
-		if(stack.isEmpty()) {
-			return ItemStack.EMPTY;
-		}
-
-		// if the item count was specified, set it for the item stack
-		if(parts.length > 1) {
-			Integer count = parseInteger(parts[1]);
-			if(count == null || count < 0) {
-				return ItemStack.EMPTY;
-			}
-			stack.setCount(count);
-		}
-		return stack;
-	}
-
-	/**
-	 * Parse a string to an integer.
-	 * @param value string
-	 * @return the integer or null if it cannot be parsed
-	 */
-	private static Integer parseInteger(String value) {
-		if(null == StringUtils.trimToNull(value)) {
-			return null;
-		}
-
-		try {
-			return Integer.valueOf(value);
-		}
-		catch (NumberFormatException e) {
-			return null;
+					fallHeight, state));
 		}
 	}
 

--- a/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
+++ b/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
@@ -364,7 +364,7 @@ public class InspirationsRegistry {
 	 */
 	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStackList output, Integer fallHeight,
 			IBlockState inputState) {
-		addAnvilItemSmashingRecipe(new AnvilItemSmashingRecipe(RecipeMatch.of(stack), output, inputState, fallHeight));
+		addAnvilItemSmashingRecipe(new AnvilItemSmashingRecipe(RecipeMatch.of(stack), output, fallHeight, inputState));
 	}
 
 	/**
@@ -407,7 +407,7 @@ public class InspirationsRegistry {
 	public static void addAnvilItemSmashingRecipe(String oreDictInput, ItemStackList outputs, Integer fallHeight,
 			IBlockState inputState) {
 		addAnvilItemSmashingRecipe(
-				new AnvilItemSmashingRecipe(RecipeMatch.of(oreDictInput), outputs, inputState, fallHeight));
+				new AnvilItemSmashingRecipe(RecipeMatch.of(oreDictInput), outputs, fallHeight, inputState));
 	}
 
 	/*

--- a/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
+++ b/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
@@ -33,8 +33,10 @@ import net.minecraft.init.Items;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.oredict.OreDictionary;
+import slimeknights.mantle.util.ItemStackList;
 import slimeknights.mantle.util.RecipeMatch;
 
 public class InspirationsRegistry {
@@ -294,14 +296,14 @@ public class InspirationsRegistry {
 
 	/**
 	 * Get the result of an anvil recipe
-	 * @param input      ItemStack input
+	 * @param inputs      List of ItemStack input
 	 * @param fallHeight the height the anvil fell from
 	 * @param state      the state of the block the anvil landed on
 	 * @return the matching recipe
 	 */
-	public static IAnvilRecipe getAnvilItemSmashingRecipe(ItemStack input, int fallHeight, IBlockState state) {
+	public static IAnvilRecipe getAnvilItemSmashingRecipe(NonNullList<ItemStack> inputs, int fallHeight, IBlockState state) {
 		for(IAnvilRecipe recipe : anvilItemSmashingRecipes) {
-			if(recipe.matches(input, fallHeight, state)) {
+			if(recipe.matches(inputs, fallHeight, state)) {
 				return recipe;
 			}
 		}
@@ -329,7 +331,7 @@ public class InspirationsRegistry {
 	 * @param stack  input item stack
 	 * @param output output item stack
 	 */
-	public static void addAnvilItemSmashingRecipe(ItemStack stack, List<ItemStack> output) {
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStackList output) {
 		addAnvilItemSmashingRecipe(stack, output, null, null);
 	}
 
@@ -339,7 +341,7 @@ public class InspirationsRegistry {
 	 * @param output     output item stack
 	 * @param inputState required block state for the block the anvil lands on
 	 */
-	public static void addAnvilItemSmashingRecipe(ItemStack stack, List<ItemStack> output, IBlockState inputState) {
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStackList output, IBlockState inputState) {
 		addAnvilItemSmashingRecipe(stack, output, null, inputState);
 	}
 
@@ -349,7 +351,7 @@ public class InspirationsRegistry {
 	 * @param output     output item stack
 	 * @param fallHeight required minimum fall height
 	 */
-	public static void addAnvilItemSmashingRecipe(ItemStack stack, List<ItemStack> output, Integer fallHeight) {
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStackList output, Integer fallHeight) {
 		addAnvilItemSmashingRecipe(stack, output, fallHeight, null);
 	}
 
@@ -360,7 +362,7 @@ public class InspirationsRegistry {
 	 * @param fallHeight required minimum fall height
 	 * @param inputState required block state for the block the anvil lands on
 	 */
-	public static void addAnvilItemSmashingRecipe(ItemStack stack, List<ItemStack> output, Integer fallHeight,
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStackList output, Integer fallHeight,
 			IBlockState inputState) {
 		addAnvilItemSmashingRecipe(new AnvilItemSmashingRecipe(RecipeMatch.of(stack), output, inputState, fallHeight));
 	}
@@ -370,7 +372,7 @@ public class InspirationsRegistry {
 	 * @param oreDictInput the ore dict name for the input
 	 * @param outputs      the output items
 	 */
-	public static void addAnvilItemSmashingRecipe(String oreDictInput, List<ItemStack> outputs) {
+	public static void addAnvilItemSmashingRecipe(String oreDictInput, ItemStackList outputs) {
 		addAnvilItemSmashingRecipe(oreDictInput, outputs, null, null);
 	}
 
@@ -380,7 +382,7 @@ public class InspirationsRegistry {
 	 * @param outputs      the output items
 	 * @param inputState   required block state for the block the anvil lands on
 	 */
-	public static void addAnvilItemSmashingRecipe(String oreDictInput, List<ItemStack> outputs,
+	public static void addAnvilItemSmashingRecipe(String oreDictInput, ItemStackList outputs,
 			IBlockState inputState) {
 		addAnvilItemSmashingRecipe(oreDictInput, outputs, null, inputState);
 	}
@@ -391,7 +393,7 @@ public class InspirationsRegistry {
 	 * @param outputs      the output items
 	 * @param fallHeight   required minimum fall height
 	 */
-	public static void addAnvilItemSmashingRecipe(String oreDictInput, List<ItemStack> outputs, Integer fallHeight) {
+	public static void addAnvilItemSmashingRecipe(String oreDictInput, ItemStackList outputs, Integer fallHeight) {
 		addAnvilItemSmashingRecipe(oreDictInput, outputs, fallHeight, null);
 	}
 
@@ -402,7 +404,7 @@ public class InspirationsRegistry {
 	 * @param fallHeight   required minimum fall height
 	 * @param inputState   required block state for the block the anvil lands on
 	 */
-	public static void addAnvilItemSmashingRecipe(String oreDictInput, List<ItemStack> outputs, Integer fallHeight,
+	public static void addAnvilItemSmashingRecipe(String oreDictInput, ItemStackList outputs, Integer fallHeight,
 			IBlockState inputState) {
 		addAnvilItemSmashingRecipe(
 				new AnvilItemSmashingRecipe(RecipeMatch.of(oreDictInput), outputs, inputState, fallHeight));

--- a/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
+++ b/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
@@ -13,6 +13,8 @@ import com.google.common.collect.ImmutableList;
 
 import knightminer.inspirations.common.Config;
 import knightminer.inspirations.library.event.RegisterEvent.RegisterCauldronRecipe;
+import knightminer.inspirations.library.recipe.anvil.AnvilItemSmashingRecipe;
+import knightminer.inspirations.library.recipe.anvil.IAnvilRecipe;
 import knightminer.inspirations.library.recipe.cauldron.CauldronFluidRecipe;
 import knightminer.inspirations.library.recipe.cauldron.CauldronFluidTransformRecipe;
 import knightminer.inspirations.library.recipe.cauldron.FillCauldronRecipe;
@@ -184,6 +186,7 @@ public class InspirationsRegistry {
 	private static Map<IBlockState, IBlockState> anvilSmashing = new HashMap<>();
 	private static Map<Block, IBlockState> anvilSmashingBlocks = new HashMap<>();
 	private static Set<Material> anvilBreaking = new HashSet<>();
+	private static List<IAnvilRecipe> anvilItemSmashingRecipes = new ArrayList<>();
 
 	/**
 	 * Registers an anvil smashing result for the given block state
@@ -289,6 +292,78 @@ public class InspirationsRegistry {
 		return ImmutableList.copyOf(anvilSmashingBlocks.entrySet());
 	}
 
+	/**
+	 * Get the result of an anvil recipe
+	 * @param input      ItemStack input
+	 * @param fallHeight the height the anvil fell from
+	 * @param state      the state of the block the anvil landed on
+	 * @return the matching recipe
+	 */
+	public static IAnvilRecipe getAnvilItemSmashingRecipe(ItemStack input, int fallHeight, IBlockState state) {
+		for(IAnvilRecipe recipe : anvilItemSmashingRecipes) {
+			if(recipe.matches(input, fallHeight, state)) {
+				return recipe;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Add a new anvil recipe
+	 * @param recipe the recipe to register
+	 */
+	public static void addAnvilItemSmashingRecipe(IAnvilRecipe recipe) {
+		anvilItemSmashingRecipes.add(recipe);
+	}
+
+	/**
+	 * Retrieve all registered recipes for item smashing.
+	 * @return list of all recipes
+	 */
+	public static List<IAnvilRecipe> getAllAnvilItemSmashingRecipes() {
+		return ImmutableList.copyOf(anvilItemSmashingRecipes);
+	}
+
+	/**
+	 * Add a new item smashing recipe for the given input and output.
+	 * @param stack  input item stack
+	 * @param output output item stack
+	 */
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStack output) {
+		addAnvilItemSmashingRecipe(stack, output, null, null);
+	}
+
+	/**
+	 * Add a new item smashing recipe for the given input and output.
+	 * @param stack      input item stack
+	 * @param output     output item stack
+	 * @param inputState required block state for the block the anvil lands on
+	 */
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStack output, IBlockState inputState) {
+		addAnvilItemSmashingRecipe(stack, output, null, inputState);
+	}
+
+	/**
+	 * Add a new item smashing recipe for the given input and output.
+	 * @param stack      input item stack
+	 * @param output     output item stack
+	 * @param fallHeight required minimum fall height
+	 */
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStack output, Integer fallHeight) {
+		addAnvilItemSmashingRecipe(stack, output, fallHeight, null);
+	}
+
+	/**
+	 * Add a new item smashing recipe for the given input and output.
+	 * @param stack      input item stack
+	 * @param output     output item stack
+	 * @param fallHeight required minimum fall height
+	 * @param inputState required block state for the block the anvil lands on
+	 */
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStack output, Integer fallHeight,
+			IBlockState inputState) {
+		addAnvilItemSmashingRecipe(new AnvilItemSmashingRecipe(RecipeMatch.of(stack), output, inputState, fallHeight));
+	}
 
 	/*
 	 * Cauldron recipes

--- a/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
+++ b/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
@@ -329,7 +329,7 @@ public class InspirationsRegistry {
 	 * @param stack  input item stack
 	 * @param output output item stack
 	 */
-	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStack output) {
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, List<ItemStack> output) {
 		addAnvilItemSmashingRecipe(stack, output, null, null);
 	}
 
@@ -339,7 +339,7 @@ public class InspirationsRegistry {
 	 * @param output     output item stack
 	 * @param inputState required block state for the block the anvil lands on
 	 */
-	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStack output, IBlockState inputState) {
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, List<ItemStack> output, IBlockState inputState) {
 		addAnvilItemSmashingRecipe(stack, output, null, inputState);
 	}
 
@@ -349,7 +349,7 @@ public class InspirationsRegistry {
 	 * @param output     output item stack
 	 * @param fallHeight required minimum fall height
 	 */
-	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStack output, Integer fallHeight) {
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, List<ItemStack> output, Integer fallHeight) {
 		addAnvilItemSmashingRecipe(stack, output, fallHeight, null);
 	}
 
@@ -360,9 +360,52 @@ public class InspirationsRegistry {
 	 * @param fallHeight required minimum fall height
 	 * @param inputState required block state for the block the anvil lands on
 	 */
-	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStack output, Integer fallHeight,
+	public static void addAnvilItemSmashingRecipe(ItemStack stack, List<ItemStack> output, Integer fallHeight,
 			IBlockState inputState) {
 		addAnvilItemSmashingRecipe(new AnvilItemSmashingRecipe(RecipeMatch.of(stack), output, inputState, fallHeight));
+	}
+
+	/**
+	 * Add a new item smashing recipe for the given ore dict input and output.
+	 * @param oreDictInput the ore dict name for the input
+	 * @param outputs      the output items
+	 */
+	public static void addAnvilItemSmashingRecipe(String oreDictInput, List<ItemStack> outputs) {
+		addAnvilItemSmashingRecipe(oreDictInput, outputs, null, null);
+	}
+
+	/**
+	 * Add a new item smashing recipe for the given ore dict input and output.
+	 * @param oreDictInput the ore dict name for the input
+	 * @param outputs      the output items
+	 * @param inputState   required block state for the block the anvil lands on
+	 */
+	public static void addAnvilItemSmashingRecipe(String oreDictInput, List<ItemStack> outputs,
+			IBlockState inputState) {
+		addAnvilItemSmashingRecipe(oreDictInput, outputs, null, inputState);
+	}
+
+	/**
+	 * Add a new item smashing recipe for the given ore dict input and output.
+	 * @param oreDictInput the ore dict name for the input
+	 * @param outputs      the output items
+	 * @param fallHeight   required minimum fall height
+	 */
+	public static void addAnvilItemSmashingRecipe(String oreDictInput, List<ItemStack> outputs, Integer fallHeight) {
+		addAnvilItemSmashingRecipe(oreDictInput, outputs, fallHeight, null);
+	}
+
+	/**
+	 * Add a new item smashing recipe for the given ore dict input and output.
+	 * @param oreDictInput the ore dict name for the input
+	 * @param outputs      the output items
+	 * @param fallHeight   required minimum fall height
+	 * @param inputState   required block state for the block the anvil lands on
+	 */
+	public static void addAnvilItemSmashingRecipe(String oreDictInput, List<ItemStack> outputs, Integer fallHeight,
+			IBlockState inputState) {
+		addAnvilItemSmashingRecipe(
+				new AnvilItemSmashingRecipe(RecipeMatch.of(oreDictInput), outputs, inputState, fallHeight));
 	}
 
 	/*

--- a/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
+++ b/src/main/java/knightminer/inspirations/library/InspirationsRegistry.java
@@ -364,7 +364,7 @@ public class InspirationsRegistry {
 	 */
 	public static void addAnvilItemSmashingRecipe(ItemStack stack, ItemStackList output, Integer fallHeight,
 			IBlockState inputState) {
-		addAnvilItemSmashingRecipe(new AnvilItemSmashingRecipe(RecipeMatch.of(stack), output, fallHeight, inputState));
+		addAnvilItemSmashingRecipe(new AnvilItemSmashingRecipe(RecipeMatch.of(stack, stack.getCount(), 1), output, fallHeight, inputState));
 	}
 
 	/**
@@ -373,7 +373,7 @@ public class InspirationsRegistry {
 	 * @param outputs      the output items
 	 */
 	public static void addAnvilItemSmashingRecipe(String oreDictInput, ItemStackList outputs) {
-		addAnvilItemSmashingRecipe(oreDictInput, outputs, null, null);
+		addAnvilItemSmashingRecipe(oreDictInput, 1, outputs, null, null);
 	}
 
 	/**
@@ -384,7 +384,7 @@ public class InspirationsRegistry {
 	 */
 	public static void addAnvilItemSmashingRecipe(String oreDictInput, ItemStackList outputs,
 			IBlockState inputState) {
-		addAnvilItemSmashingRecipe(oreDictInput, outputs, null, inputState);
+		addAnvilItemSmashingRecipe(oreDictInput, 1, outputs, null, inputState);
 	}
 
 	/**
@@ -394,20 +394,21 @@ public class InspirationsRegistry {
 	 * @param fallHeight   required minimum fall height
 	 */
 	public static void addAnvilItemSmashingRecipe(String oreDictInput, ItemStackList outputs, Integer fallHeight) {
-		addAnvilItemSmashingRecipe(oreDictInput, outputs, fallHeight, null);
+		addAnvilItemSmashingRecipe(oreDictInput, 1, outputs, fallHeight, null);
 	}
 
 	/**
 	 * Add a new item smashing recipe for the given ore dict input and output.
 	 * @param oreDictInput the ore dict name for the input
+	 * @param inputAmount   number of inputs required
 	 * @param outputs      the output items
 	 * @param fallHeight   required minimum fall height
 	 * @param inputState   required block state for the block the anvil lands on
 	 */
-	public static void addAnvilItemSmashingRecipe(String oreDictInput, ItemStackList outputs, Integer fallHeight,
+	public static void addAnvilItemSmashingRecipe(String oreDictInput, int inputAmount, ItemStackList outputs, Integer fallHeight,
 			IBlockState inputState) {
 		addAnvilItemSmashingRecipe(
-				new AnvilItemSmashingRecipe(RecipeMatch.of(oreDictInput), outputs, fallHeight, inputState));
+				new AnvilItemSmashingRecipe(RecipeMatch.of(oreDictInput, inputAmount, 1), outputs, fallHeight, inputState));
 	}
 
 	/*

--- a/src/main/java/knightminer/inspirations/library/Util.java
+++ b/src/main/java/knightminer/inspirations/library/Util.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -193,5 +194,24 @@ public class Util {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Safely get an integer from a string.
+	 * @param value string
+	 * @return the integer or null if it cannot be parsed
+	 */
+	public static Integer getInteger(String value) {
+		String trimmed = StringUtils.trimToNull(value);
+		if(null == trimmed) {
+			return null;
+		}
+
+		try {
+			return Integer.valueOf(trimmed);
+		}
+		catch (NumberFormatException e) {
+			return null;
+		}
 	}
 }

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/AnvilItemSmashingRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/AnvilItemSmashingRecipe.java
@@ -1,0 +1,134 @@
+package knightminer.inspirations.library.recipe.anvil;
+
+import knightminer.inspirations.library.Util;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import slimeknights.mantle.util.RecipeMatch;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+
+@ParametersAreNonnullByDefault
+public class AnvilItemSmashingRecipe implements ISimpleAnvilRecipe {
+	protected RecipeMatch input;
+	private ItemStack result;
+	@Nullable
+	protected IBlockState state;
+	@Nullable
+	private Integer fallHeight;
+
+	public AnvilItemSmashingRecipe(RecipeMatch input, ItemStack result, @Nullable IBlockState state,
+			@Nullable Integer fallHeight) {
+		this.input = input;
+		this.result = result;
+		this.state = state;
+		this.fallHeight = fallHeight;
+	}
+
+	public AnvilItemSmashingRecipe(RecipeMatch input, ItemStack result, @Nullable IBlockState state) {
+		this(input, result, state, null);
+	}
+
+	public AnvilItemSmashingRecipe(RecipeMatch input, ItemStack result, @Nullable Integer fallHeight) {
+		this(input, result, null, fallHeight);
+	}
+
+	public AnvilItemSmashingRecipe(RecipeMatch input, ItemStack result) {
+		this(input, result, null, null);
+	}
+
+	@Override
+	public boolean matches(ItemStack stack, int height, IBlockState state) {
+		// match the conditions if they are set
+		if(!fallHeightMatches(height) || !stateMatches(state)) {
+			return false;
+		}
+
+		return this.input.matches(Util.createNonNullList(stack)).isPresent();
+	}
+
+	/**
+	 * Match the actual block state to the required one.
+	 * @param state input block state
+	 * @return true if there is either no requirement for a specific block state or it matches the actual one
+	 */
+	private boolean stateMatches(IBlockState state) {
+		return this.state == null || state == this.state;
+	}
+
+	/**
+	 * Match the actual fall height to the required one.
+	 * @param height the actual fall height of the anvil
+	 * @return true if there is either no fall height requirement or the actual height is greater or equal to it
+	 */
+	private boolean fallHeightMatches(int height) {
+		return this.fallHeight == null || height >= this.fallHeight;
+	}
+
+	@Override
+	public List<ItemStack> getInput() {
+		return input.getInputs();
+	}
+
+	@Override
+	public ItemStack getResult() {
+		return result;
+	}
+
+	@Override
+	@Nullable
+	public Integer getFallHeight() {
+		return fallHeight;
+	}
+
+	@Override
+	public NonNullList<ItemStack> transformInput(ItemStack stack, int fallHeight, IBlockState state) {
+		// assume this recipe matches, otherwise this method shouldn't have been called
+		RecipeMatch.Match match = input.matches(Util.createNonNullList(stack)).get();
+
+		// calculate the number of times this recipe can be applied to the input item stack
+		int matchCount = stack.getCount() / match.amount;
+
+		// calculate the remainder of the input item stack that doesn't fit with the recipe
+		int remainder = stack.getCount() % match.amount;
+
+		// modify the input stack
+		stack.setCount(remainder);
+
+		// transform the output stack
+		int totalCount = result.getCount() * matchCount;
+		return getItemStacks(result, totalCount);
+	}
+
+	/**
+	 * Creates item stacks from the template that sum up to the given total count and respect the max stack size for
+	 * the item.
+	 * @param template   the template item stack, is read only
+	 * @param totalCount the sum of all item stacks
+	 * @return a list of non empty item stacks whose counts sum up to the given total
+	 */
+	public static NonNullList<ItemStack> getItemStacks(@Nonnull ItemStack template, int totalCount) {
+		NonNullList<ItemStack> outList = NonNullList.create();
+
+		// respect max stack size of the template
+		int maxStackSize = template.getMaxStackSize();
+
+		int remainingStackSize = totalCount;
+		while(remainingStackSize > 0) {
+			ItemStack out = template.copy();
+			int count = Math.min(maxStackSize, remainingStackSize);
+			out.setCount(count);
+			outList.add(out);
+			remainingStackSize -= count;
+		}
+		return outList;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("AnvilItemSmashingRecipe: %s from %s", result.toString(), input.getInputs());
+	}
+}

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/AnvilItemSmashingRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/AnvilItemSmashingRecipe.java
@@ -1,6 +1,7 @@
 package knightminer.inspirations.library.recipe.anvil;
 
 import java.util.List;
+import java.util.Optional;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
@@ -13,29 +14,51 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class AnvilItemSmashingRecipe implements ISimpleAnvilRecipe {
-	protected RecipeMatch input;
+	private RecipeMatch input;
 	private ItemStackList result;
-	@Nullable
-	protected IBlockState state;
-	@Nullable
+	private IBlockState state;
 	private Integer fallHeight;
 
-	public AnvilItemSmashingRecipe(RecipeMatch input, ItemStackList result, @Nullable IBlockState state,
-			@Nullable Integer fallHeight) {
+	/**
+	 * Recipe for item smashing
+	 * @param input matcher for the inputs
+	 * @param result list of results
+	 * @param fallHeight required minimum fall height, can be null if there is no requirement
+	 * @param state required input block state, can be null if there is no requirement
+	 */
+	public AnvilItemSmashingRecipe(RecipeMatch input, ItemStackList result, @Nullable Integer fallHeight,
+			@Nullable IBlockState state) {
 		this.input = input;
 		this.result = result;
 		this.state = state;
 		this.fallHeight = fallHeight;
 	}
 
+	/**
+	 * Recipe for item smashing
+	 * @param input matcher for the inputs
+	 * @param result list of results
+	 * @param state required input block state, can be null if there is no requirement
+	 */
 	public AnvilItemSmashingRecipe(RecipeMatch input, ItemStackList result, @Nullable IBlockState state) {
-		this(input, result, state, null);
+		this(input, result, null, state);
 	}
 
+	/**
+	 * Recipe for item smashing
+	 * @param input matcher for the inputs
+	 * @param result list of results
+	 * @param fallHeight required minimum fall height, can be null if there is no requirement
+	 */
 	public AnvilItemSmashingRecipe(RecipeMatch input, ItemStackList result, @Nullable Integer fallHeight) {
-		this(input, result, null, fallHeight);
+		this(input, result, fallHeight, null);
 	}
 
+	/**
+	 * Recipe for item smashing
+	 * @param input matcher for the inputs
+	 * @param result list of results
+	 */
 	public AnvilItemSmashingRecipe(RecipeMatch input, ItemStackList result) {
 		this(input, result, null, null);
 	}
@@ -79,18 +102,17 @@ public class AnvilItemSmashingRecipe implements ISimpleAnvilRecipe {
 	}
 
 	@Override
-	@Nullable
-	public Integer getFallHeight() {
-		return fallHeight;
+	public Optional<Integer> getFallHeight() {
+		return Optional.ofNullable(fallHeight);
 	}
 
 	@Override
-	public Object getInputState() {
-		return this.state;
+	public Optional<IBlockState> getState() {
+		return Optional.ofNullable(this.state);
 	}
 
 	@Override
-	public NonNullList<ItemStack> transformInput(NonNullList<ItemStack> stack, int fallHeight, IBlockState state) {
+	public NonNullList<ItemStack> getOutputs(NonNullList<ItemStack> stack, int fallHeight, IBlockState state) {
 		// assume this recipe matches, otherwise this method shouldn't have been called
 		RecipeMatch.Match match = input.matches(stack).get();
 

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/CompositeRecipeMatch.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/CompositeRecipeMatch.java
@@ -1,0 +1,77 @@
+package knightminer.inspirations.library.recipe.anvil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import slimeknights.mantle.util.RecipeMatch;
+
+/**
+ * Composite recipe match of multiple individual matches. This assumes the matches are mutual exclusive, otherwise
+ * this won't work!
+ */
+public class CompositeRecipeMatch extends RecipeMatch {
+
+	private final List<? extends RecipeMatch> recipeMatches;
+	private final List<ItemStack> inputs;
+
+	private CompositeRecipeMatch(List<? extends RecipeMatch> matches, int amountMatched, int amountNeeded) {
+		super(amountMatched, amountNeeded);
+
+		this.recipeMatches = matches;
+		this.inputs = matches.stream().flatMap(match -> match.getInputs().stream()).collect(Collectors.toList());
+	}
+
+	@Override
+	public List<ItemStack> getInputs() {
+		return ImmutableList.copyOf(this.inputs);
+	}
+
+	@Override
+	public Optional<Match> matches(NonNullList<ItemStack> stacks) {
+		List<ItemStack> matchedStacks = Lists.newArrayList();
+
+		// must match everything
+		if(!this.recipeMatches.stream().map(match -> match.matches(stacks)).allMatch(match -> {
+			if(match.isPresent()) {
+				matchedStacks.addAll(match.get().stacks);
+				return true;
+			}
+			return false;
+		})) {
+			return Optional.empty();
+		}
+
+		return Optional.of(new Match(matchedStacks, amountMatched));
+	}
+
+	/**
+	 * Create a new composite recipe match. If there is only one input the original object will be used instead of
+	 * the composite wrapper
+	 * @param matches the recipe matches to compose
+	 * @return the recipe match object composing all the matches or the single match if there is exactly one
+	 */
+	public static RecipeMatch of(RecipeMatch... matches) {
+		return ofMatches(Arrays.asList(matches));
+	}
+
+	/**
+	 * Create a new composite recipe match. If there is only one input the original object will be used instead of
+	 * the composite wrapper
+	 * @param matches  the recipe matches to compose
+	 * @return the recipe match object composing all the matches or the single match if there is exactly one
+	 */
+	public static RecipeMatch ofMatches(List<? extends RecipeMatch> matches) {
+		// If there is only one input use that instead of a complex wrapper around it
+		if(matches.size() == 1) {
+			return matches.get(0);
+		}
+		return new CompositeRecipeMatch(matches, 1, 1);
+	}
+}

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/CompositeRecipeMatch.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/CompositeRecipeMatch.java
@@ -33,6 +33,10 @@ public class CompositeRecipeMatch extends RecipeMatch {
 		return ImmutableList.copyOf(this.inputs);
 	}
 
+	public List<? extends RecipeMatch> getRecipeMatches() {
+		return recipeMatches;
+	}
+
 	@Override
 	public Optional<Match> matches(NonNullList<ItemStack> stacks) {
 		List<ItemStack> matchedStacks = Lists.newArrayList();

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/IAnvilRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/IAnvilRecipe.java
@@ -10,7 +10,7 @@ import net.minecraft.util.NonNullList;
  * based on the recipe
  * <p>
  * Parameters are considered stateless and generally should not modify the input stack except in the case of
- * transformInput()
+ * getOutputs()
  */
 public interface IAnvilRecipe {
 	/**
@@ -31,5 +31,5 @@ public interface IAnvilRecipe {
 	 * @param state  State of the block the anvil landed on
 	 * @return
 	 */
-	NonNullList<ItemStack> transformInput(NonNullList<ItemStack> stack, int height, IBlockState state);
+	NonNullList<ItemStack> getOutputs(NonNullList<ItemStack> stack, int height, IBlockState state);
 }

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/IAnvilRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/IAnvilRecipe.java
@@ -1,0 +1,62 @@
+package knightminer.inspirations.library.recipe.anvil;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.SoundEvent;
+
+import java.util.List;
+
+/**
+ * Base interface for all anvil recipes. Contains all methods required to determine new state, itemstack, and height
+ * based on the recipe
+ * <p>
+ * Parameters are considered stateless and generally should not modify the input stack except in the case of
+ * transformInput()
+ */
+public interface IAnvilRecipe {
+	/**
+	 * Checks if the recipe matches the given input
+	 *
+	 * @param stack  Input stack
+	 * @param height Fall height of the anvil
+	 * @param state  State of the block the anvil landed on
+	 * @return true if the recipe matches
+	 */
+	boolean matches(ItemStack stack, int height, IBlockState state);
+
+	/**
+	 * Gets the result stack for this recipe
+	 *
+	 * @param stack  Input stack
+	 * @param height Fall height of the anvil
+	 * @param state  State of the block the anvil landed on
+	 * @return ItemStack result
+	 */
+	default ItemStack getResult(ItemStack stack, int height, IBlockState state) {
+		return ItemStack.EMPTY;
+	}
+
+	/**
+	 * Transforms the input itemstack for the recipe.
+	 *
+	 * @param stack  Input stack to transform
+	 * @param height Fall height of the anvil
+	 * @param state  State of the block the anvil landed on
+	 * @return
+	 */
+	NonNullList<ItemStack> transformInput(ItemStack stack, int height, IBlockState state);
+
+	/**
+	 * Get the resulting block state for this recipe
+	 *
+	 * @param stack  Input stack
+	 * @param height Fall height of the anvil
+	 * @param state  State of the block the anvil landed on
+	 * @return new block state
+	 */
+	default IBlockState getState(ItemStack stack, int height, IBlockState state) {
+		return state;
+	}
+}

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/IAnvilRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/IAnvilRecipe.java
@@ -1,12 +1,9 @@
 package knightminer.inspirations.library.recipe.anvil;
 
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraft.util.SoundEvent;
 
-import java.util.List;
 
 /**
  * Base interface for all anvil recipes. Contains all methods required to determine new state, itemstack, and height
@@ -24,7 +21,7 @@ public interface IAnvilRecipe {
 	 * @param state  State of the block the anvil landed on
 	 * @return true if the recipe matches
 	 */
-	boolean matches(ItemStack stack, int height, IBlockState state);
+	boolean matches(NonNullList<ItemStack> stack, int height, IBlockState state);
 
 	/**
 	 * Transforms the input itemstack for the recipe.
@@ -34,17 +31,5 @@ public interface IAnvilRecipe {
 	 * @param state  State of the block the anvil landed on
 	 * @return
 	 */
-	List<ItemStack> transformInput(ItemStack stack, int height, IBlockState state);
-
-	/**
-	 * Get the resulting block state for this recipe
-	 *
-	 * @param stack  Input stack
-	 * @param height Fall height of the anvil
-	 * @param state  State of the block the anvil landed on
-	 * @return new block state
-	 */
-	default IBlockState getState(ItemStack stack, int height, IBlockState state) {
-		return state;
-	}
+	NonNullList<ItemStack> transformInput(NonNullList<ItemStack> stack, int height, IBlockState state);
 }

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/IAnvilRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/IAnvilRecipe.java
@@ -27,18 +27,6 @@ public interface IAnvilRecipe {
 	boolean matches(ItemStack stack, int height, IBlockState state);
 
 	/**
-	 * Gets the result stack for this recipe
-	 *
-	 * @param stack  Input stack
-	 * @param height Fall height of the anvil
-	 * @param state  State of the block the anvil landed on
-	 * @return ItemStack result
-	 */
-	default ItemStack getResult(ItemStack stack, int height, IBlockState state) {
-		return ItemStack.EMPTY;
-	}
-
-	/**
 	 * Transforms the input itemstack for the recipe.
 	 *
 	 * @param stack  Input stack to transform
@@ -46,7 +34,7 @@ public interface IAnvilRecipe {
 	 * @param state  State of the block the anvil landed on
 	 * @return
 	 */
-	NonNullList<ItemStack> transformInput(ItemStack stack, int height, IBlockState state);
+	List<ItemStack> transformInput(ItemStack stack, int height, IBlockState state);
 
 	/**
 	 * Get the resulting block state for this recipe

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/ISimpleAnvilRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/ISimpleAnvilRecipe.java
@@ -1,0 +1,68 @@
+package knightminer.inspirations.library.recipe.anvil;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+
+import java.util.List;
+
+/**
+ * This is any anvil recipe using items simple enough to be displayed in JEI
+ */
+public interface ISimpleAnvilRecipe extends IAnvilRecipe {
+	/**
+	 * Gets the inputs of the recipe for display in JEI
+	 *
+	 * @return Recipe inputs
+	 */
+	List<ItemStack> getInput();
+
+	/**
+	 * Gets the result of this recipe for display in JEI
+	 *
+	 * @return Recipe result
+	 */
+	default ItemStack getResult() {
+		return ItemStack.EMPTY;
+	}
+
+	/**
+	 * Gets whether this recipe requires the cauldron to be above fire
+	 *
+	 * @return True if the recipe requires fire
+	 */
+	default boolean isBoiling() {
+		return false;
+	}
+
+	/**
+	 * Gets the input block state of this recipe for display in JEI.
+	 *
+	 * @return Input block state
+	 */
+	default Object getInputState() {
+		return null;
+	}
+
+	/**
+	 * Gets the result block state of this recipe for display in JEI.
+	 *
+	 * @return Result state as a Fluid, EnumDyeColor, or PotionType
+	 */
+	default Object getState() {
+		return getInputState();
+	}
+
+	/**
+	 * Gets the fall height requirement for display in JEI.
+	 *
+	 * @return
+	 */
+	default Integer getFallHeight() {
+		return null;
+	}
+
+	@Override default ItemStack getResult(ItemStack stack, int height, IBlockState state) {
+		return getResult().copy();
+	}
+
+}

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/ISimpleAnvilRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/ISimpleAnvilRecipe.java
@@ -1,6 +1,5 @@
 package knightminer.inspirations.library.recipe.anvil;
 
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
 import java.util.List;
@@ -21,18 +20,7 @@ public interface ISimpleAnvilRecipe extends IAnvilRecipe {
 	 *
 	 * @return Recipe result
 	 */
-	default ItemStack getResult() {
-		return ItemStack.EMPTY;
-	}
-
-	/**
-	 * Gets whether this recipe requires the cauldron to be above fire
-	 *
-	 * @return True if the recipe requires fire
-	 */
-	default boolean isBoiling() {
-		return false;
-	}
+	List<ItemStack> getResult();
 
 	/**
 	 * Gets the input block state of this recipe for display in JEI.
@@ -44,25 +32,12 @@ public interface ISimpleAnvilRecipe extends IAnvilRecipe {
 	}
 
 	/**
-	 * Gets the result block state of this recipe for display in JEI.
-	 *
-	 * @return Result state as a Fluid, EnumDyeColor, or PotionType
-	 */
-	default Object getState() {
-		return getInputState();
-	}
-
-	/**
 	 * Gets the fall height requirement for display in JEI.
 	 *
 	 * @return
 	 */
 	default Integer getFallHeight() {
 		return null;
-	}
-
-	@Override default ItemStack getResult(ItemStack stack, int height, IBlockState state) {
-		return getResult().copy();
 	}
 
 }

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/ISimpleAnvilRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/ISimpleAnvilRecipe.java
@@ -1,8 +1,10 @@
 package knightminer.inspirations.library.recipe.anvil;
 
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This is any anvil recipe using items simple enough to be displayed in JEI
@@ -25,19 +27,19 @@ public interface ISimpleAnvilRecipe extends IAnvilRecipe {
 	/**
 	 * Gets the input block state of this recipe for display in JEI.
 	 *
-	 * @return Input block state
+	 * @return Input block state, returns empty if there is no requirement
 	 */
-	default Object getInputState() {
-		return null;
+	default Optional<IBlockState> getState() {
+		return Optional.empty();
 	}
 
 	/**
 	 * Gets the fall height requirement for display in JEI.
 	 *
-	 * @return
+	 * @return the required fall height, returns empty if there is no requirement
 	 */
-	default Integer getFallHeight() {
-		return null;
+	default Optional<Integer> getFallHeight() {
+		return Optional.empty();
 	}
 
 }

--- a/src/main/java/knightminer/inspirations/library/recipe/anvil/ISimpleAnvilRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/anvil/ISimpleAnvilRecipe.java
@@ -15,7 +15,7 @@ public interface ISimpleAnvilRecipe extends IAnvilRecipe {
 	 *
 	 * @return Recipe inputs
 	 */
-	List<ItemStack> getInput();
+	List<List<ItemStack>> getInput();
 
 	/**
 	 * Gets the result of this recipe for display in JEI

--- a/src/main/java/knightminer/inspirations/library/recipe/cauldron/ICauldronRecipe.java
+++ b/src/main/java/knightminer/inspirations/library/recipe/cauldron/ICauldronRecipe.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fluids.FluidStack;
 /**
  * Base interface for all cauldron recipes. Contains all methods required to determine new state, itemstack, and level based on the recipe
  *
- * Parameters are considered stateless and generally should not modify the input stack except in the case of transformInput()
+ * Parameters are considered stateless and generally should not modify the input stack except in the case of getOutputs()
  */
 public interface ICauldronRecipe {
 

--- a/src/main/java/knightminer/inspirations/plugins/jei/JEIPlugin.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/JEIPlugin.java
@@ -18,6 +18,7 @@ import knightminer.inspirations.plugins.jei.cauldron.ingredient.DyeIngredientRen
 import knightminer.inspirations.plugins.jei.cauldron.ingredient.PotionIngredient;
 import knightminer.inspirations.plugins.jei.cauldron.ingredient.PotionIngredientHelper;
 import knightminer.inspirations.plugins.jei.cauldron.ingredient.PotionIngredientRenderer;
+import knightminer.inspirations.plugins.jei.smashing.SmashingItemRecipeCategory;
 import knightminer.inspirations.plugins.jei.smashing.SmashingRecipeCategory;
 import knightminer.inspirations.plugins.jei.smashing.SmashingRecipeChecker;
 import knightminer.inspirations.plugins.jei.texture.TextureRecipeHandler;
@@ -71,6 +72,7 @@ public class JEIPlugin implements IModPlugin {
 			// Anvil
 			if(Config.enableAnvilSmashing) {
 				registry.addRecipeCategories(new SmashingRecipeCategory(guiHelper));
+				registry.addRecipeCategories(new SmashingItemRecipeCategory(guiHelper));
 			}
 			// cauldron
 			if(Config.enableCauldronRecipes) {
@@ -93,6 +95,9 @@ public class JEIPlugin implements IModPlugin {
 			if(Config.enableAnvilSmashing) {
 				registry.addRecipes(SmashingRecipeChecker.getRecipes(), SmashingRecipeCategory.CATEGORY);
 				registry.addRecipeCatalyst(new ItemStack(Blocks.ANVIL), SmashingRecipeCategory.CATEGORY);
+
+				registry.addRecipes(SmashingRecipeChecker.getItemRecipes(), SmashingItemRecipeCategory.CATEGORY);
+				registry.addRecipeCatalyst(new ItemStack(Blocks.ANVIL), SmashingItemRecipeCategory.CATEGORY);
 			}
 			if(Config.enableCauldronRecipes) {
 				registry.addRecipes(CauldronRecipeChecker.getRecipes(), CauldronRecipeCategory.CATEGORY);

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeCategory.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeCategory.java
@@ -1,0 +1,65 @@
+package knightminer.inspirations.plugins.jei.smashing;
+
+import knightminer.inspirations.Inspirations;
+import knightminer.inspirations.library.Util;
+import mezz.jei.api.IGuiHelper;
+import mezz.jei.api.gui.IDrawable;
+import mezz.jei.api.gui.IGuiItemStackGroup;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeCategory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nonnull;
+
+public class SmashingItemRecipeCategory implements IRecipeCategory<SmashingRecipeWrapper> {
+
+	public static final String CATEGORY = Util.prefix("anvil_smashing_items");
+	public static final ResourceLocation BACKGROUND_LOC = Util.getResource("textures/gui/jei/anvil_smashing.png");
+
+	private final IDrawable background;
+
+	public SmashingItemRecipeCategory(IGuiHelper guiHelper) {
+		background = guiHelper.createDrawable(BACKGROUND_LOC, 0, 0, 160, 33, 0, 4, 0, 0);
+	}
+
+	@Nonnull
+	@Override
+	public String getUid() {
+		return CATEGORY;
+	}
+
+	@Nonnull
+	@Override
+	public String getTitle() {
+		return Util.translate("gui.jei.anvil_smashing_items.title");
+	}
+
+	@Nonnull
+	@Override
+	public IDrawable getBackground() {
+		return background;
+	}
+
+	@Override
+	public void setRecipe(IRecipeLayout recipeLayout, SmashingRecipeWrapper recipeWrapper, IIngredients ingredients) {
+		IGuiItemStackGroup items = recipeLayout.getItemStacks();
+
+		items.init(0, true, 43, 15);
+		items.set(ingredients);
+
+		items.init(1, false, 97, 15);
+
+		int numAdditionalOutputs = ingredients.getOutputs(ItemStack.class).size() - 1;
+		for(int i = 0; i < Math.min(numAdditionalOutputs, 3); i++) {
+			items.init(2 + i, false, 97 + 20*(i+1), 15);
+		}
+		items.set(ingredients);
+	}
+
+	@Override
+	public String getModName() {
+		return Inspirations.modName;
+	}
+}

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeCategory.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeCategory.java
@@ -21,7 +21,7 @@ public class SmashingItemRecipeCategory implements IRecipeCategory<SmashingItemR
 	private final IDrawable background;
 
 	public SmashingItemRecipeCategory(IGuiHelper guiHelper) {
-		background = guiHelper.createDrawable(BACKGROUND_LOC, 0, 0, 160, 33, 0, 4, 0, 0);
+		background = guiHelper.createDrawable(BACKGROUND_LOC, 0, -14, 160, 50, 0, 4, 0, 0);
 	}
 
 	@Nonnull
@@ -42,6 +42,8 @@ public class SmashingItemRecipeCategory implements IRecipeCategory<SmashingItemR
 		return background;
 	}
 
+	private static final int ABOVE_Y = -6;
+
 	@Override
 	public void setRecipe(IRecipeLayout recipeLayout, SmashingItemRecipeWrapper recipeWrapper, IIngredients ingredients) {
 		IGuiItemStackGroup items = recipeLayout.getItemStacks();
@@ -49,18 +51,25 @@ public class SmashingItemRecipeCategory implements IRecipeCategory<SmashingItemR
 		int slot = 0;
 
 		// Input
-		items.init(slot++, true, 43, 15);
+		items.init(slot++, true, 43, ABOVE_Y);
 		int numAdditionalInputs = ingredients.getInputs(ItemStack.class).size() - 1;
 		for(int i = 0; i < Math.min(numAdditionalInputs, 3); i++) {
-			items.init(slot++, true, 43 - 20*(i+1), 15);
+			items.init(slot++, true, 43 - 20*(i+1), ABOVE_Y);
 		}
 		items.set(ingredients);
 
+		int finalSlot = slot;
+		slot += recipeWrapper.getRecipe().getState().map(state -> {
+			items.init(finalSlot, true, 43, 32);
+			items.set(finalSlot, new ItemStack(state.getBlock()));
+			return 1;
+		}).orElse(0);
+
 		// Output
-		items.init(slot++, false, 97, 15);
+		items.init(slot++, false, 97, ABOVE_Y);
 		int numAdditionalOutputs = ingredients.getOutputs(ItemStack.class).size() - 1;
 		for(int i = 0; i < Math.min(numAdditionalOutputs, 3); i++) {
-			items.init(slot++, false, 97 + 20*(i+1), 15);
+			items.init(slot++, false, 97 + 20*(i+1), ABOVE_Y);
 		}
 		items.set(ingredients);
 	}

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeCategory.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeCategory.java
@@ -13,7 +13,7 @@ import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.Nonnull;
 
-public class SmashingItemRecipeCategory implements IRecipeCategory<SmashingRecipeWrapper> {
+public class SmashingItemRecipeCategory implements IRecipeCategory<SmashingItemRecipeWrapper> {
 
 	public static final String CATEGORY = Util.prefix("anvil_smashing_items");
 	public static final ResourceLocation BACKGROUND_LOC = Util.getResource("textures/gui/jei/anvil_smashing.png");
@@ -43,17 +43,24 @@ public class SmashingItemRecipeCategory implements IRecipeCategory<SmashingRecip
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayout recipeLayout, SmashingRecipeWrapper recipeWrapper, IIngredients ingredients) {
+	public void setRecipe(IRecipeLayout recipeLayout, SmashingItemRecipeWrapper recipeWrapper, IIngredients ingredients) {
 		IGuiItemStackGroup items = recipeLayout.getItemStacks();
 
-		items.init(0, true, 43, 15);
+		int slot = 0;
+
+		// Input
+		items.init(slot++, true, 43, 15);
+		int numAdditionalInputs = ingredients.getInputs(ItemStack.class).size() - 1;
+		for(int i = 0; i < Math.min(numAdditionalInputs, 3); i++) {
+			items.init(slot++, true, 43 - 20*(i+1), 15);
+		}
 		items.set(ingredients);
 
-		items.init(1, false, 97, 15);
-
+		// Output
+		items.init(slot++, false, 97, 15);
 		int numAdditionalOutputs = ingredients.getOutputs(ItemStack.class).size() - 1;
 		for(int i = 0; i < Math.min(numAdditionalOutputs, 3); i++) {
-			items.init(2 + i, false, 97 + 20*(i+1), 15);
+			items.init(slot++, false, 97 + 20*(i+1), 15);
 		}
 		items.set(ingredients);
 	}

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeWrapper.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeWrapper.java
@@ -1,0 +1,74 @@
+package knightminer.inspirations.plugins.jei.smashing;
+
+import java.awt.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import knightminer.inspirations.library.Util;
+import knightminer.inspirations.library.recipe.anvil.ISimpleAnvilRecipe;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
+
+public class SmashingItemRecipeWrapper implements IRecipeWrapper {
+
+	protected final ISimpleAnvilRecipe recipe;
+	private final List<List<ItemStack>> input;
+	private final ImmutableList<ItemStack> output;
+
+	private String heightRequirementString;
+	private String blockRequirementString;
+
+	public SmashingItemRecipeWrapper(ISimpleAnvilRecipe recipe) {
+		this.recipe = recipe;
+		this.input = this.recipe.getInput().stream().map(ImmutableList::of).collect(Collectors.toList());
+		this.output = ImmutableList.copyOf(this.recipe.getResult());
+
+		Integer minFallHeight = recipe.getFallHeight();
+		this.heightRequirementString =
+				minFallHeight != null ? Util.translateFormatted("gui.jei.anvil_smashing.height", minFallHeight) : null;
+
+		Object inputState = recipe.getInputState();
+		this.blockRequirementString = inputState instanceof IBlockState ?
+				Util.translateFormatted("gui.jei.anvil_smashing.blockstate",
+						((IBlockState) inputState).getBlock().getLocalizedName()) :
+				null;
+	}
+
+	@Override
+	public void getIngredients(IIngredients ingredients) {
+		ingredients.setInputLists(ItemStack.class, input);
+		ingredients.setOutputs(ItemStack.class, output);
+	}
+
+	@Override
+	public List<String> getTooltipStrings(int mouseX, int mouseY) {
+		List<String> tooltip = Lists.newArrayList();
+		if(mouseX >= 68 && mouseX <= 90 && mouseY >= 17 && mouseY <= 31) {
+			if(isNotEmpty(heightRequirementString)) {
+				tooltip.add(heightRequirementString);
+			}
+
+			if(isNotEmpty(blockRequirementString)) {
+				tooltip.add(blockRequirementString);
+			}
+		}
+		return tooltip;
+	}
+
+	@Override
+	public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+		if(isNotEmpty(heightRequirementString) || isNotEmpty(blockRequirementString)) {
+			minecraft.fontRenderer.drawString("!", 76, 13, Color.gray.getRGB());
+		}
+	}
+
+	private boolean isNotEmpty(String string) {
+		return string != null && !string.isEmpty();
+	}
+}

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeWrapper.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingItemRecipeWrapper.java
@@ -3,21 +3,14 @@ package knightminer.inspirations.plugins.jei.smashing;
 import java.awt.*;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.function.IntPredicate;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.Validate;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import knightminer.inspirations.library.Util;
 import knightminer.inspirations.library.recipe.anvil.ISimpleAnvilRecipe;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeWrapper;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 
@@ -34,7 +27,7 @@ public class SmashingItemRecipeWrapper implements IRecipeWrapper {
 
 	public SmashingItemRecipeWrapper(ISimpleAnvilRecipe recipe) {
 		this.recipe = recipe;
-		this.input = this.recipe.getInput().stream().map(ImmutableList::of).collect(Collectors.toList());
+		this.input = recipe.getInput();
 		this.output = ImmutableList.copyOf(this.recipe.getResult());
 
 		Optional<Integer> minFallHeight = recipe.getFallHeight();

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeChecker.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeChecker.java
@@ -6,6 +6,8 @@ import java.util.Map;
 
 import knightminer.inspirations.library.InspirationsRegistry;
 import knightminer.inspirations.library.Util;
+import knightminer.inspirations.library.recipe.anvil.IAnvilRecipe;
+import knightminer.inspirations.library.recipe.anvil.ISimpleAnvilRecipe;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -27,6 +29,15 @@ public class SmashingRecipeChecker {
 			ItemStack output = Util.getStackFromState(entry.getValue());
 			if(entry.getKey() != Blocks.AIR && !output.isEmpty()) {
 				recipes.add(new SmashingRecipeWrapper(entry.getKey(), output));
+			}
+		}
+
+		// item stacks
+		for(IAnvilRecipe recipe : InspirationsRegistry.getAllAnvilItemSmashingRecipes()) {
+			if(recipe instanceof ISimpleAnvilRecipe) {
+				ISimpleAnvilRecipe simpleRecipe = (ISimpleAnvilRecipe) recipe;
+				recipes.add(new SmashingRecipeWrapper(simpleRecipe.getInput(), simpleRecipe.getResult(),
+						simpleRecipe.getFallHeight()));
 			}
 		}
 

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeChecker.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeChecker.java
@@ -32,6 +32,12 @@ public class SmashingRecipeChecker {
 			}
 		}
 
+
+		return recipes;
+	}
+
+	public static List<SmashingRecipeWrapper> getItemRecipes() {
+		List<SmashingRecipeWrapper> recipes = new ArrayList<>();
 		// item stacks
 		for(IAnvilRecipe recipe : InspirationsRegistry.getAllAnvilItemSmashingRecipes()) {
 			if(recipe instanceof ISimpleAnvilRecipe) {
@@ -40,7 +46,6 @@ public class SmashingRecipeChecker {
 						simpleRecipe.getFallHeight()));
 			}
 		}
-
 		return recipes;
 	}
 }

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeChecker.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeChecker.java
@@ -36,14 +36,13 @@ public class SmashingRecipeChecker {
 		return recipes;
 	}
 
-	public static List<SmashingRecipeWrapper> getItemRecipes() {
-		List<SmashingRecipeWrapper> recipes = new ArrayList<>();
+	public static List<SmashingItemRecipeWrapper> getItemRecipes() {
+		List<SmashingItemRecipeWrapper> recipes = new ArrayList<>();
 		// item stacks
 		for(IAnvilRecipe recipe : InspirationsRegistry.getAllAnvilItemSmashingRecipes()) {
 			if(recipe instanceof ISimpleAnvilRecipe) {
 				ISimpleAnvilRecipe simpleRecipe = (ISimpleAnvilRecipe) recipe;
-				recipes.add(new SmashingRecipeWrapper(simpleRecipe.getInput(), simpleRecipe.getResult(),
-						simpleRecipe.getFallHeight()));
+				recipes.add(new SmashingItemRecipeWrapper(simpleRecipe));
 			}
 		}
 		return recipes;

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeWrapper.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeWrapper.java
@@ -1,16 +1,20 @@
 package knightminer.inspirations.plugins.jei.smashing;
 
+import java.awt.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import knightminer.inspirations.library.InspirationsRegistry;
-import net.minecraft.block.Block;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.NonNullList;
-
-import java.util.List;
-
+import knightminer.inspirations.library.Util;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import slimeknights.mantle.client.CreativeTab;
 
 public class SmashingRecipeWrapper implements IRecipeWrapper {
@@ -18,9 +22,17 @@ public class SmashingRecipeWrapper implements IRecipeWrapper {
 	protected final List<List<ItemStack>> input;
 	protected final List<ItemStack> output;
 
+	private String heightRequirementString;
+
 	public SmashingRecipeWrapper(ItemStack input, ItemStack output) {
 		this.input = ImmutableList.of(ImmutableList.of(input));
 		this.output = ImmutableList.of(output);
+	}
+
+	public SmashingRecipeWrapper(List<ItemStack> inputs, ItemStack output, Integer minFallHeight) {
+		this.input = inputs.stream().map(ImmutableList::of).collect(Collectors.toList());
+		this.output = ImmutableList.of(output);
+		this.heightRequirementString = Util.translateFormatted("gui.jei.anvil_smashing.height", minFallHeight);
 	}
 
 	@SuppressWarnings("deprecation")
@@ -39,5 +51,27 @@ public class SmashingRecipeWrapper implements IRecipeWrapper {
 	public void getIngredients(IIngredients ingredients) {
 		ingredients.setInputLists(ItemStack.class, input);
 		ingredients.setOutputs(ItemStack.class, output);
+	}
+
+	@Override
+	public List<String> getTooltipStrings(int mouseX, int mouseY) {
+		List<String> tooltip = Lists.newArrayList();
+		if (mouseX >= 68 && mouseX <= 90 && mouseY >= 17 && mouseY <= 31) {
+			if (isNotEmpty(heightRequirementString)) {
+				tooltip.add(heightRequirementString);
+			}
+		}
+		return tooltip;
+	}
+
+	@Override
+	public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+		if (isNotEmpty(heightRequirementString)) {
+			minecraft.fontRenderer.drawString("!", 76, 13, Color.gray.getRGB());
+		}
+	}
+
+	private boolean isNotEmpty(String string) {
+		return string != null && !string.isEmpty();
 	}
 }

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeWrapper.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeWrapper.java
@@ -1,20 +1,16 @@
 package knightminer.inspirations.plugins.jei.smashing;
 
-import java.awt.*;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import knightminer.inspirations.library.InspirationsRegistry;
-import knightminer.inspirations.library.Util;
-import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.block.Block;
-import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
+
+import java.util.List;
+
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeWrapper;
 import slimeknights.mantle.client.CreativeTab;
 
 public class SmashingRecipeWrapper implements IRecipeWrapper {
@@ -22,17 +18,9 @@ public class SmashingRecipeWrapper implements IRecipeWrapper {
 	protected final List<List<ItemStack>> input;
 	protected final List<ItemStack> output;
 
-	private String heightRequirementString;
-
 	public SmashingRecipeWrapper(ItemStack input, ItemStack output) {
 		this.input = ImmutableList.of(ImmutableList.of(input));
 		this.output = ImmutableList.of(output);
-	}
-
-	public SmashingRecipeWrapper(List<ItemStack> inputs, List<ItemStack> output, Integer minFallHeight) {
-		this.input = inputs.stream().map(ImmutableList::of).collect(Collectors.toList());
-		this.output = ImmutableList.copyOf(output);
-		this.heightRequirementString = minFallHeight != null ? Util.translateFormatted("gui.jei.anvil_smashing.height", minFallHeight) : null;
 	}
 
 	@SuppressWarnings("deprecation")
@@ -51,27 +39,5 @@ public class SmashingRecipeWrapper implements IRecipeWrapper {
 	public void getIngredients(IIngredients ingredients) {
 		ingredients.setInputLists(ItemStack.class, input);
 		ingredients.setOutputs(ItemStack.class, output);
-	}
-
-	@Override
-	public List<String> getTooltipStrings(int mouseX, int mouseY) {
-		List<String> tooltip = Lists.newArrayList();
-		if (mouseX >= 68 && mouseX <= 90 && mouseY >= 17 && mouseY <= 31) {
-			if (isNotEmpty(heightRequirementString)) {
-				tooltip.add(heightRequirementString);
-			}
-		}
-		return tooltip;
-	}
-
-	@Override
-	public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
-		if (isNotEmpty(heightRequirementString)) {
-			minecraft.fontRenderer.drawString("!", 76, 13, Color.gray.getRGB());
-		}
-	}
-
-	private boolean isNotEmpty(String string) {
-		return string != null && !string.isEmpty();
 	}
 }

--- a/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeWrapper.java
+++ b/src/main/java/knightminer/inspirations/plugins/jei/smashing/SmashingRecipeWrapper.java
@@ -29,10 +29,10 @@ public class SmashingRecipeWrapper implements IRecipeWrapper {
 		this.output = ImmutableList.of(output);
 	}
 
-	public SmashingRecipeWrapper(List<ItemStack> inputs, ItemStack output, Integer minFallHeight) {
+	public SmashingRecipeWrapper(List<ItemStack> inputs, List<ItemStack> output, Integer minFallHeight) {
 		this.input = inputs.stream().map(ImmutableList::of).collect(Collectors.toList());
-		this.output = ImmutableList.of(output);
-		this.heightRequirementString = Util.translateFormatted("gui.jei.anvil_smashing.height", minFallHeight);
+		this.output = ImmutableList.copyOf(output);
+		this.heightRequirementString = minFallHeight != null ? Util.translateFormatted("gui.jei.anvil_smashing.height", minFallHeight) : null;
 	}
 
 	@SuppressWarnings("deprecation")

--- a/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
+++ b/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 
 public class BlockSmashingAnvil extends BlockAnvil {
 
+	private static final int MAX_RECIPE_APPLICATIONS = 64;
+
 	public BlockSmashingAnvil() {
 		this.setHardness(5.0F);
 		this.setSoundType(SoundType.ANVIL);
@@ -61,7 +63,8 @@ public class BlockSmashingAnvil extends BlockAnvil {
 		// repeat as long as a recipe matches
 		List<ItemStack> results = new ArrayList<>();
 		boolean recipeApplied = false;
-		while(true) {
+		int iterations = 0;
+		while(iterations++ < MAX_RECIPE_APPLICATIONS) {
 			// find next match
 			IAnvilRecipe recipe = InspirationsRegistry.getAnvilItemSmashingRecipe(inputs, fallHeight, state);
 			if(recipe == null) {

--- a/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
+++ b/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
@@ -76,7 +76,7 @@ public class BlockSmashingAnvil extends BlockAnvil {
 			recipeApplied = true;
 
 			// apply the recipe once
-			List<ItemStack> itemStackRemaining = recipe.transformInput(inputs, fallHeight, state);
+			List<ItemStack> itemStackRemaining = recipe.getOutputs(inputs, fallHeight, state);
 			results.addAll(itemStackRemaining);
 		}
 

--- a/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
+++ b/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
@@ -62,7 +62,7 @@ public class BlockSmashingAnvil extends BlockAnvil {
 		}
 
 		// apply the recipe
-		NonNullList<ItemStack> itemStackRemaining = recipe.transformInput(inputStack, fallHeight, state);
+		List<ItemStack> itemStackRemaining = recipe.transformInput(inputStack, fallHeight, state);
 		itemStackRemaining.forEach(itemStack -> {
 			if(!itemStack.isEmpty()) {
 				spawnAsEntity(world, pos, itemStack);

--- a/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
+++ b/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
@@ -16,13 +16,10 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class BlockSmashingAnvil extends BlockAnvil {
-
-	private static final int MAX_RECIPE_APPLICATIONS = 64;
 
 	public BlockSmashingAnvil() {
 		this.setHardness(5.0F);
@@ -60,25 +57,15 @@ public class BlockSmashingAnvil extends BlockAnvil {
 
 		int fallHeight = getFallHeight(world, pos);
 
-		// repeat as long as a recipe matches
-		List<ItemStack> results = new ArrayList<>();
-		boolean recipeApplied = false;
-		int iterations = 0;
-		while(iterations++ < MAX_RECIPE_APPLICATIONS) {
-			// find next match
-			IAnvilRecipe recipe = InspirationsRegistry.getAnvilItemSmashingRecipe(inputs, fallHeight, state);
-			if(recipe == null) {
-				// no more match
-				break;
-			}
-
-			// at least one recipe was applied
-			recipeApplied = true;
-
-			// apply the recipe once
-			List<ItemStack> itemStackRemaining = recipe.getOutputs(inputs, fallHeight, state);
-			results.addAll(itemStackRemaining);
+		// find first match for the inputs
+		IAnvilRecipe recipe = InspirationsRegistry.getAnvilItemSmashingRecipe(inputs, fallHeight, state);
+		if(recipe == null) {
+			// no more match
+			return false;
 		}
+
+		// apply the recipe
+		List<ItemStack> results = recipe.getOutputs(inputs, fallHeight, state);
 
 		// Output the result stacks
 		results.forEach(itemStack -> {
@@ -93,7 +80,7 @@ public class BlockSmashingAnvil extends BlockAnvil {
 				entity.setDead();
 			}
 		});
-		return recipeApplied;
+		return true;
 	}
 
 	/**

--- a/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
+++ b/src/main/java/knightminer/inspirations/recipes/block/BlockSmashingAnvil.java
@@ -1,13 +1,22 @@
 package knightminer.inspirations.recipes.block;
 
+import com.google.common.collect.Iterables;
 import knightminer.inspirations.library.InspirationsRegistry;
+import knightminer.inspirations.library.recipe.anvil.IAnvilRecipe;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockAnvil;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.item.EntityFallingBlock;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+
+import java.util.List;
 
 public class BlockSmashingAnvil extends BlockAnvil {
 
@@ -21,9 +30,101 @@ public class BlockSmashingAnvil extends BlockAnvil {
 	@Override
 	public void onEndFalling(World world, BlockPos pos, IBlockState anvil, IBlockState state) {
 		BlockPos down = pos.down();
-		if(!smashBlock(world, down, world.getBlockState(down))) {
+		IBlockState blockState = world.getBlockState(down);
+		// smash the items and then the block and do both in combination
+		if(!smashItem(world, down.up(), blockState) & !smashBlock(world, down, blockState)) {
 			super.onEndFalling(world, pos, anvil, state);
 		}
+	}
+
+	/**
+	 * Smash an item stack in the world with an anvil
+	 * @param world the world
+	 * @param pos the position the anvil landed on
+	 * @param state the state of the block the anvil landed on
+	 * @return true if the item was smashed
+	 */
+	public static boolean smashItem(World world, BlockPos pos, IBlockState state) {
+		// find item entities that can be smashed
+		EntityItem entityItem = getItemEntity(world, pos);
+		if (entityItem == null) {
+			return false;
+		}
+		ItemStack inputStack = entityItem.getItem();
+
+		int fallHeight = getFallHeight(world, pos);
+
+		// is there a recipe that matches?
+		IAnvilRecipe recipe = InspirationsRegistry
+				.getAnvilItemSmashingRecipe(inputStack, fallHeight, state);
+		if(recipe == null) {
+			return false;
+		}
+
+		// apply the recipe
+		NonNullList<ItemStack> itemStackRemaining = recipe.transformInput(inputStack, fallHeight, state);
+		itemStackRemaining.forEach(itemStack -> {
+			if(!itemStack.isEmpty()) {
+				spawnAsEntity(world, pos, itemStack);
+			}
+		});
+
+		// if the input stack is now empty, remove it from the world
+		if(inputStack.isEmpty()) {
+			entityItem.setDead();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Find the fall height of the anvil
+	 * @param world the world
+	 * @param pos the position of the anvil
+	 * @return the fall height
+	 */
+	private static int getFallHeight(World world, BlockPos pos) {
+		// since there is no direct access to the entity use the first one in the given position
+		EntityFallingBlock entity = Iterables.getFirst(world
+				.getEntitiesWithinAABB(EntityFallingBlock.class, new AxisAlignedBB(pos),
+						BlockSmashingAnvil::isAnvilEntity), null);
+		return entity != null ? getYDifference(entity.getOrigin(), pos) : 0;
+	}
+
+	/**
+	 * Check if the falling block entity is an anvil
+	 * @param input the entity
+	 * @return true if the entity is a falling anvil
+	 */
+	private static boolean isAnvilEntity(EntityFallingBlock input) {
+		IBlockState state = input.getBlock();
+		return state != null && state.getBlock() == Blocks.ANVIL;
+	}
+
+	/**
+	 * Find the difference in y position between the two positions
+	 * @param high the higher position
+	 * @param low the lower position
+	 * @return the Y level difference or 0 if the upper position is lower
+	 */
+	private static int getYDifference(BlockPos high, BlockPos low) {
+		int highY = high.getY();
+		int lowY = low.getY();
+		return highY < lowY ? 0 : highY - lowY;
+	}
+
+	/**
+	 * Retrieve the first item entity in the world at the given position.
+	 *
+	 * @param world the world to look in
+	 * @param pos   the position to look in
+	 * @return the first item entity. Standard rules of entity access for minecraft applies, so no
+	 * guarantees what entity will be picked!
+	 */
+	private static EntityItem getItemEntity(World world, BlockPos pos) {
+		List<EntityItem> entitiesWithinAABB = world
+				.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(pos));
+		return Iterables.getFirst(entitiesWithinAABB, null);
 	}
 
 	public static boolean smashBlock(World world, BlockPos pos, IBlockState state) {

--- a/src/main/resources/assets/inspirations/lang/de_de.lang
+++ b/src/main/resources/assets/inspirations/lang/de_de.lang
@@ -160,8 +160,8 @@ gui.jei.cauldron.level.singular=1 Flasche
 gui.jei.cauldron.level.empty=Leer
 gui.jei.cauldron.color=%s gefärbtes Wasser
 gui.jei.cauldron.boiling=Kessel muss über Feuer platziert werden
-gui.jei.anvil_smashing.height=Minimale Fallhöhe: %s Blöcke
-gui.jei.anvil_smashing.blockstate=Landeblock: %s
+gui.jei.anvil_smashing.height=≥%s
+gui.jei.anvil_smashing.height.text=Minimale Fallhöhe
 
 ############
 #  Tweaks  #

--- a/src/main/resources/assets/inspirations/lang/de_de.lang
+++ b/src/main/resources/assets/inspirations/lang/de_de.lang
@@ -153,13 +153,14 @@ fluid.inspirations.rabbit_stew=Kaninchenragout
 
 # JEI
 gui.jei.anvil_smashing.title=Amboss-Zerschlagung
+gui.jei.anvil_smashing_items.title=Amboss-Zerschlagung: Gegenstände
 gui.jei.cauldron.title=Kessel
 gui.jei.cauldron.level=%s Flaschen
 gui.jei.cauldron.level.singular=1 Flasche
 gui.jei.cauldron.level.empty=Leer
 gui.jei.cauldron.color=%s gefärbtes Wasser
 gui.jei.cauldron.boiling=Kessel muss über Feuer platziert werden
-
+gui.jei.anvil_smashing.height=Minimale Fallhöhe: %s Blöcke
 
 ############
 #  Tweaks  #

--- a/src/main/resources/assets/inspirations/lang/de_de.lang
+++ b/src/main/resources/assets/inspirations/lang/de_de.lang
@@ -161,6 +161,7 @@ gui.jei.cauldron.level.empty=Leer
 gui.jei.cauldron.color=%s gefärbtes Wasser
 gui.jei.cauldron.boiling=Kessel muss über Feuer platziert werden
 gui.jei.anvil_smashing.height=Minimale Fallhöhe: %s Blöcke
+gui.jei.anvil_smashing.blockstate=Landeblock: %s
 
 ############
 #  Tweaks  #

--- a/src/main/resources/assets/inspirations/lang/en_us.lang
+++ b/src/main/resources/assets/inspirations/lang/en_us.lang
@@ -153,13 +153,14 @@ gui.inspirations.cauldron.color=Color: %s
 
 # JEI
 gui.jei.anvil_smashing.title=Anvil Smashing
+gui.jei.anvil_smashing_items.title=Anvil Smashing: Items
 gui.jei.cauldron.title=Cauldron
 gui.jei.cauldron.level=%s bottles
 gui.jei.cauldron.level.singular=1 bottle
 gui.jei.cauldron.level.empty=Empty
 gui.jei.cauldron.color=%s Dyed Water
 gui.jei.cauldron.boiling=Cauldron must be placed above fire
-gui.jei.anvil_smashing.height=Minimum Fall Height: %s
+gui.jei.anvil_smashing.height=Minimum Fall Height: %s blocks
 
 # WAILA
 options.inspirations.cauldron=Cauldron

--- a/src/main/resources/assets/inspirations/lang/en_us.lang
+++ b/src/main/resources/assets/inspirations/lang/en_us.lang
@@ -160,8 +160,8 @@ gui.jei.cauldron.level.singular=1 bottle
 gui.jei.cauldron.level.empty=Empty
 gui.jei.cauldron.color=%s Dyed Water
 gui.jei.cauldron.boiling=Cauldron must be placed above fire
-gui.jei.anvil_smashing.height=Minimum Fall Height: %s blocks
-gui.jei.anvil_smashing.blockstate=Must land on block: %s
+gui.jei.anvil_smashing.height=≥%s
+gui.jei.anvil_smashing.height.text=Minimum fall height
 
 # WAILA
 options.inspirations.cauldron=Cauldron

--- a/src/main/resources/assets/inspirations/lang/en_us.lang
+++ b/src/main/resources/assets/inspirations/lang/en_us.lang
@@ -159,6 +159,7 @@ gui.jei.cauldron.level.singular=1 bottle
 gui.jei.cauldron.level.empty=Empty
 gui.jei.cauldron.color=%s Dyed Water
 gui.jei.cauldron.boiling=Cauldron must be placed above fire
+gui.jei.anvil_smashing.height=Minimum Fall Height: %s
 
 # WAILA
 options.inspirations.cauldron=Cauldron

--- a/src/main/resources/assets/inspirations/lang/en_us.lang
+++ b/src/main/resources/assets/inspirations/lang/en_us.lang
@@ -161,6 +161,7 @@ gui.jei.cauldron.level.empty=Empty
 gui.jei.cauldron.color=%s Dyed Water
 gui.jei.cauldron.boiling=Cauldron must be placed above fire
 gui.jei.anvil_smashing.height=Minimum Fall Height: %s blocks
+gui.jei.anvil_smashing.blockstate=Must land on block: %s
 
 # WAILA
 options.inspirations.cauldron=Cauldron


### PR DESCRIPTION
I re-implemented the system to smash items with the anvil (mostly) according to the specs we discussed on discord:
- Multiple inputs (specific item or ore dict name).
- Multiple outputs.
- Requirement for minimum fall height of the anvil.
- Requirement for specific state of the block the anvil lands on.
- Separate JEI category for the recipes with a very basic textual representation of height and block requirements.

I implemented everything similar to the cauldron recipes and used RecipeMatch. However I needed to implement a custom sub class in order to allow multiple inputs. Maybe this is something that already exists and I didn't find it? Is there a better way to implement it? Otherwise that class could also be moved to Mantle.

The JEI implementation is very basic at the moment. Because of limited space it is limited to only display 3 inputs and 3 outputs. The requirements for the fall height and the block state are shown via tooltips.

I also included a few example recipes in the default config to demonstrate and test the configuration. 

Please let me know what should be changed, especially the logic for applying the recipes I'm not too sure about. I included a hard limit for the number of times recipes are applied per "anvil operation" in order to limit the number of item entities as well as the computation time.

This PR replaces #69 which can be closed.