### PR TITLE
fixed crash on latest recommended Forge version (14.23.5.2768), fixes #89

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ build
 eclipse
 run
 libs
+classes/

--- a/build.properties
+++ b/build.properties
@@ -1,7 +1,7 @@
 mod_version=0.2.2
 minecraft_version=1.12.2
 minecraft_base_version=1.12
-forge_version=14.23.2.2624
+forge_version=14.23.5.2768
 mappings=snapshot_20171003
 mantle_version=1.3.1.+
 

--- a/src/main/java/knightminer/inspirations/library/Util.java
+++ b/src/main/java/knightminer/inspirations/library/Util.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import knightminer.inspirations.library.util.ReflectionUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,7 +24,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.translation.I18n;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
 @SuppressWarnings("deprecation")
 public class Util {
@@ -80,10 +80,7 @@ public class Util {
 
 		// first try getSilkTouchDrop, which just has to be protected
 		try {
-			Object stack = ReflectionHelper.findMethod(Block.class, "getSilkTouchDrop", "func_180643_i", IBlockState.class).invoke(block, state);
-			if(stack instanceof ItemStack) {
-				return (ItemStack) stack;
-			}
+			return ReflectionUtil.invokeGetSilkTouchDrop(block, state);
 		} catch (Exception e) {
 			InspirationsRegistry.log.error(e);
 		}

--- a/src/main/java/knightminer/inspirations/library/Util.java
+++ b/src/main/java/knightminer/inspirations/library/Util.java
@@ -79,10 +79,9 @@ public class Util {
 		}
 
 		// first try getSilkTouchDrop, which just has to be protected
-		try {
-			return ReflectionUtil.invokeGetSilkTouchDrop(block, state);
-		} catch (Exception e) {
-			InspirationsRegistry.log.error(e);
+		ItemStack drop = ReflectionUtil.invokeGetSilkTouchDrop(block, state);
+		if( drop != null ) { // stack is null if reflection fails
+			return drop;
 		}
 
 		// if it fails, do a fallback of damageDropped and item.getItemFromBlock

--- a/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
+++ b/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
@@ -1,5 +1,6 @@
 package knightminer.inspirations.library.util;
 
+import knightminer.inspirations.library.InspirationsRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
@@ -8,6 +9,8 @@ import net.minecraft.potion.PotionType;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.registries.IRegistryDelegate;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -15,28 +18,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 @SuppressWarnings("unchecked")
-public final class ReflectionUtil
-{
+public final class ReflectionUtil {
 	private ReflectionUtil() {}
 
-	private static final Map<Integer, Field> FIELDS = new HashMap<>();
-	private static final Map<Integer, Method> METHODS = new HashMap<>();
+	private static final Map<String, Field> FIELDS = new HashMap<>();
+	private static final Map<String, Method> METHODS = new HashMap<>();
 
-	public static PotionType getMixPredicateInput(Object mixPredicate) {
-		Object val = getFieldValue(mixPredicate, "input", "field_185198_a", 0, false);
-		if( val instanceof IRegistryDelegate ) {
-			return ((IRegistryDelegate<PotionType>) val).get();
-		} else { // fallback for older Forge versions
-			return (PotionType) val;
-		}
-	}
-
-	public static Ingredient getMixPredicateReagent(Object mixPredicate) {
-		return getFieldValue(mixPredicate, "reagent", "field_185199_b", 1, false);
-	}
-
-	public static PotionType getMixPredicateOutput(Object mixPredicate) {
-		Object val = getFieldValue(mixPredicate, "output", "field_185200_c", 2, false);
+	@Nullable
+	public static PotionType getMixPredicateInput(@Nonnull Object mixPredicate) {
+		Object val = getFieldValue(mixPredicate, "input", "field_185198_a");
 		if(val instanceof IRegistryDelegate) {
 			return ((IRegistryDelegate<PotionType>) val).get();
 		} else { // fallback for older Forge versions
@@ -44,8 +34,24 @@ public final class ReflectionUtil
 		}
 	}
 
-	public static ItemStack invokeGetSilkTouchDrop(Block block, IBlockState state) {
-		ItemStack stack = invokeMethod(block, "getSilkTouchDrop", "func_180643_i", 0, true, new Class[] {IBlockState.class}, state);
+	@Nullable
+	public static Ingredient getMixPredicateReagent(@Nonnull Object mixPredicate) {
+		return getFieldValue(mixPredicate, "reagent", "field_185199_b");
+	}
+
+	@Nullable
+	public static PotionType getMixPredicateOutput(@Nonnull Object mixPredicate) {
+		Object val = getFieldValue(mixPredicate, "output", "field_185200_c");
+		if(val instanceof IRegistryDelegate) {
+			return ((IRegistryDelegate<PotionType>) val).get();
+		} else { // fallback for older Forge versions
+			return (PotionType) val;
+		}
+	}
+
+	@Nullable
+	public static ItemStack invokeGetSilkTouchDrop(@Nonnull Block block, IBlockState state) {
+		ItemStack stack = invokeMethod(block, "getSilkTouchDrop", "func_180643_i", new Class[] {IBlockState.class}, state);
 		if(stack != null) {
 			return stack;
 		} else {
@@ -53,39 +59,51 @@ public final class ReflectionUtil
 		}
 	}
 
-	private static <T> T invokeMethod(Object instance, String mcpName, String srgName, int index, boolean throwException, Class[] paramTypes, Object... params) {
-		Method m = METHODS.get(index);
-		if(m == null) {
-			m = ReflectionHelper.findMethod(instance.getClass(), srgName, mcpName, paramTypes);
-			METHODS.put(index, m);
-		}
+	/**
+	 * Searches the instance for the occurrence of a method either named by its SRG name (obfuscated) or MCP name (development),
+	 * caches the reference for further use, invokes the method and returns the value returned by the invocation (or <tt>null</tt>, if the method is <tt>void</tt>).<br>
+	 * If it can't find the method or something went wrong during invocation, it will be logged and <tt>null</tt> is returned.
+	 *
+	 * @param instance The instance to be accessed. Cannot be <tt>null</tt>!
+	 * @param mcpName The name used in a development environment
+	 * @param srgName The name used in an obfuscated environment
+	 * @param <T> The type of the return value. Must be the same as or a superclass of the return type of the method! {@link Object}, if the method is <tt>void</tt>
+	 *
+	 * @return The return value of the method or null, if it fails or the method is <tt>void</tt>
+	 */
+	@Nullable
+	private static <T> T invokeMethod(@Nonnull final Object instance, final String mcpName, final String srgName, final Class[] paramTypes, final Object... params) {
+		Method m = METHODS.computeIfAbsent(srgName, key -> ReflectionHelper.findMethod(instance.getClass(), key, mcpName, paramTypes));
 
 		try {
 			return (T) m.invoke(instance, params);
-		} catch(IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-			if(throwException) {
-				throw new RuntimeException(e);
-			} else {
-				return null;
-			}
+		} catch(IllegalAccessException | IllegalArgumentException | InvocationTargetException | ClassCastException e) {
+			InspirationsRegistry.log.error(e);
+			return null;
 		}
 	}
 
-	private static <T> T getFieldValue(Object instance, String mcpName, String srgName, int index, boolean throwException) {
-		Field f = FIELDS.get(index);
-		if(f == null) {
-			f = ReflectionHelper.findField(instance.getClass(), srgName, mcpName);
-			FIELDS.put(index, f);
-		}
+	/**
+	 * Searches the instance for the occurrence of a field either named by its SRG name (obfuscated) or MCP name (development),
+	 * caches the reference for further use and returns the value of the field.<br>
+	 * If it can't find the field or something went wrong with getting the value, it will be logged and <tt>null</tt> is returned.
+	 *
+	 * @param instance The instance to be accessed. Cannot be <tt>null</tt>!
+	 * @param mcpName The name used in a development environment
+	 * @param srgName The name used in an obfuscated environment
+	 * @param <T> The type of the return value. Must be the same as or a superclass of the type of the field!
+	 *
+	 * @return The value of the field or null, if it fails
+	 */
+	@Nullable
+	private static <T> T getFieldValue(@Nonnull final Object instance, final String mcpName, final String srgName) {
+		Field f = FIELDS.computeIfAbsent(srgName, key -> ReflectionHelper.findField(instance.getClass(), key, mcpName));
 
 		try {
 			return (T) f.get(instance);
-		} catch(IllegalAccessException e) {
-			if(throwException) {
-				throw new RuntimeException(e);
-			} else {
-				return null;
-			}
+		} catch(IllegalAccessException | ClassCastException e) {
+			InspirationsRegistry.log.error(e);
+			return null;
 		}
 	}
 }

--- a/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
+++ b/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
@@ -2,44 +2,46 @@ package knightminer.inspirations.library.util;
 
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.potion.PotionType;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.registries.IRegistryDelegate;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
+@SuppressWarnings("unchecked")
 public final class ReflectionUtil
 {
 	private ReflectionUtil() {}
 
 	private static final Map<Integer, Field> FIELDS = new HashMap<>();
 
-	public static IRegistryDelegate<PotionType> getMixPredicateInput(Object mixPredicate) {
-		return getFieldValue(mixPredicate, "input", "field_185198_a", 0);
+	public static PotionType getMixPredicateInput(Object mixPredicate) {
+		Object val = getFieldValue(mixPredicate, "input", "field_185198_a", 0);
+		if( val instanceof IRegistryDelegate ) {
+			return ((IRegistryDelegate<PotionType>) val).get();
+		} else { // fallback for older Forge versions
+			return (PotionType) val;
+		}
 	}
 
 	public static Ingredient getMixPredicateReagent(Object mixPredicate) {
 		return getFieldValue(mixPredicate, "reagent", "field_185199_b", 1);
 	}
 
-	public static IRegistryDelegate<PotionType> getMixPredicateOutput(Object mixPredicate) {
-		return getFieldValue(mixPredicate, "output", "field_185200_c", 2);
+	public static PotionType getMixPredicateOutput(Object mixPredicate) {
+		Object val = getFieldValue(mixPredicate, "output", "field_185200_c", 2);
+		if( val instanceof IRegistryDelegate ) {
+			return ((IRegistryDelegate<PotionType>) val).get();
+		} else { // fallback for older Forge versions
+			return (PotionType) val;
+		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private static <T> T getFieldValue(Object instance, String mcpName, String srgName, int index) {
 		Field f = FIELDS.get(index);
 		if(f == null) {
-			try {
-				f = instance.getClass().getDeclaredField(srgName);
-			} catch(NoSuchFieldException e) {
-				try {
-					f = instance.getClass().getDeclaredField(mcpName);
-				} catch(NoSuchFieldException ex) {
-					throw new RuntimeException("Could not access Field " + instance.getClass().getName() + '#' + mcpName, ex);
-				}
-			}
-			f.setAccessible(true);
+			f = ReflectionHelper.findField(instance.getClass(), srgName, mcpName);
 			FIELDS.put(index, f);
 		}
 

--- a/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
+++ b/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
@@ -1,0 +1,52 @@
+package knightminer.inspirations.library.util;
+
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.potion.PotionType;
+import net.minecraftforge.registries.IRegistryDelegate;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ReflectionUtil
+{
+	private ReflectionUtil() {}
+
+	private static final Map<Integer, Field> FIELDS = new HashMap<>();
+
+	public static IRegistryDelegate<PotionType> getMixPredicateInput(Object mixPredicate) {
+		return getFieldValue(mixPredicate, "input", "field_185198_a", 0);
+	}
+
+	public static Ingredient getMixPredicateReagent(Object mixPredicate) {
+		return getFieldValue(mixPredicate, "reagent", "field_185199_b", 1);
+	}
+
+	public static IRegistryDelegate<PotionType> getMixPredicateOutput(Object mixPredicate) {
+		return getFieldValue(mixPredicate, "output", "field_185200_c", 2);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T getFieldValue(Object instance, String mcpName, String srgName, int index) {
+		Field f = FIELDS.get(index);
+		if(f == null) {
+			try {
+				f = instance.getClass().getDeclaredField(srgName);
+			} catch(NoSuchFieldException e) {
+				try {
+					f = instance.getClass().getDeclaredField(mcpName);
+				} catch(NoSuchFieldException ex) {
+					throw new RuntimeException("Could not access Field " + instance.getClass().getName() + '#' + mcpName, ex);
+				}
+			}
+			f.setAccessible(true);
+			FIELDS.put(index, f);
+		}
+
+		try {
+			return (T) f.get(instance);
+		} catch( IllegalAccessException e ) {
+			return null;
+		}
+	}
+}

--- a/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
+++ b/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
@@ -56,12 +56,7 @@ public final class ReflectionUtil {
 
 	@Nullable
 	public static ItemStack invokeGetSilkTouchDrop(@Nonnull Block block, IBlockState state) {
-		ItemStack stack = invokeMethod(Block.class, block, "getSilkTouchDrop", "func_180643_i", new Class[] {IBlockState.class}, state);
-		if(stack != null) {
-			return stack;
-		} else {
-			return ItemStack.EMPTY;
-		}
+		return invokeMethod(Block.class, block, "getSilkTouchDrop", "func_180643_i", new Class[] {IBlockState.class}, state);
 	}
 
 	/**

--- a/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
+++ b/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
@@ -1,11 +1,16 @@
 package knightminer.inspirations.library.util;
 
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.potion.PotionType;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.registries.IRegistryDelegate;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,9 +20,10 @@ public final class ReflectionUtil
 	private ReflectionUtil() {}
 
 	private static final Map<Integer, Field> FIELDS = new HashMap<>();
+	private static final Map<Integer, Method> METHODS = new HashMap<>();
 
 	public static PotionType getMixPredicateInput(Object mixPredicate) {
-		Object val = getFieldValue(mixPredicate, "input", "field_185198_a", 0);
+		Object val = getFieldValue(mixPredicate, "input", "field_185198_a", 0, false);
 		if( val instanceof IRegistryDelegate ) {
 			return ((IRegistryDelegate<PotionType>) val).get();
 		} else { // fallback for older Forge versions
@@ -26,19 +32,46 @@ public final class ReflectionUtil
 	}
 
 	public static Ingredient getMixPredicateReagent(Object mixPredicate) {
-		return getFieldValue(mixPredicate, "reagent", "field_185199_b", 1);
+		return getFieldValue(mixPredicate, "reagent", "field_185199_b", 1, false);
 	}
 
 	public static PotionType getMixPredicateOutput(Object mixPredicate) {
-		Object val = getFieldValue(mixPredicate, "output", "field_185200_c", 2);
-		if( val instanceof IRegistryDelegate ) {
+		Object val = getFieldValue(mixPredicate, "output", "field_185200_c", 2, false);
+		if(val instanceof IRegistryDelegate) {
 			return ((IRegistryDelegate<PotionType>) val).get();
 		} else { // fallback for older Forge versions
 			return (PotionType) val;
 		}
 	}
 
-	private static <T> T getFieldValue(Object instance, String mcpName, String srgName, int index) {
+	public static ItemStack invokeGetSilkTouchDrop(Block block, IBlockState state) {
+		ItemStack stack = invokeMethod(block, "getSilkTouchDrop", "func_180643_i", 0, true, new Class[] {IBlockState.class}, state);
+		if(stack != null) {
+			return stack;
+		} else {
+			return ItemStack.EMPTY;
+		}
+	}
+
+	private static <T> T invokeMethod(Object instance, String mcpName, String srgName, int index, boolean throwException, Class[] paramTypes, Object... params) {
+		Method m = METHODS.get(index);
+		if(m == null) {
+			m = ReflectionHelper.findMethod(instance.getClass(), srgName, mcpName, paramTypes);
+			METHODS.put(index, m);
+		}
+
+		try {
+			return (T) m.invoke(instance, params);
+		} catch(IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			if(throwException) {
+				throw new RuntimeException(e);
+			} else {
+				return null;
+			}
+		}
+	}
+
+	private static <T> T getFieldValue(Object instance, String mcpName, String srgName, int index, boolean throwException) {
 		Field f = FIELDS.get(index);
 		if(f == null) {
 			f = ReflectionHelper.findField(instance.getClass(), srgName, mcpName);
@@ -47,8 +80,12 @@ public final class ReflectionUtil
 
 		try {
 			return (T) f.get(instance);
-		} catch( IllegalAccessException e ) {
-			return null;
+		} catch(IllegalAccessException e) {
+			if(throwException) {
+				throw new RuntimeException(e);
+			} else {
+				return null;
+			}
 		}
 	}
 }

--- a/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
+++ b/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
@@ -1,5 +1,6 @@
 package knightminer.inspirations.library.util;
 
+import knightminer.inspirations.Inspirations;
 import knightminer.inspirations.library.InspirationsRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -7,6 +8,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.potion.PotionType;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import net.minecraftforge.fml.relauncher.ReflectionHelper.UnableToFindFieldException;
+import net.minecraftforge.fml.relauncher.ReflectionHelper.UnableToFindMethodException;
+import net.minecraftforge.fml.relauncher.ReflectionHelper.UnableToFindClassException;
 import net.minecraftforge.registries.IRegistryDelegate;
 
 import javax.annotation.Nonnull;
@@ -23,10 +27,11 @@ public final class ReflectionUtil {
 
 	private static final Map<String, Field> FIELDS = new HashMap<>();
 	private static final Map<String, Method> METHODS = new HashMap<>();
+	private static final Map<String, Class> CLASS = new HashMap<>();
 
 	@Nullable
 	public static PotionType getMixPredicateInput(@Nonnull Object mixPredicate) {
-		Object val = getFieldValue(mixPredicate, "input", "field_185198_a");
+		Object val = getFieldValue(getClass("net.minecraft.potion.PotionHelper$MixPredicate"), mixPredicate, "input", "field_185198_a");
 		if(val instanceof IRegistryDelegate) {
 			return ((IRegistryDelegate<PotionType>) val).get();
 		} else { // fallback for older Forge versions
@@ -36,12 +41,12 @@ public final class ReflectionUtil {
 
 	@Nullable
 	public static Ingredient getMixPredicateReagent(@Nonnull Object mixPredicate) {
-		return getFieldValue(mixPredicate, "reagent", "field_185199_b");
+		return getFieldValue(getClass("net.minecraft.potion.PotionHelper$MixPredicate"), mixPredicate, "reagent", "field_185199_b");
 	}
 
 	@Nullable
 	public static PotionType getMixPredicateOutput(@Nonnull Object mixPredicate) {
-		Object val = getFieldValue(mixPredicate, "output", "field_185200_c");
+		Object val = getFieldValue(getClass("net.minecraft.potion.PotionHelper$MixPredicate"), mixPredicate, "output", "field_185200_c");
 		if(val instanceof IRegistryDelegate) {
 			return ((IRegistryDelegate<PotionType>) val).get();
 		} else { // fallback for older Forge versions
@@ -51,11 +56,28 @@ public final class ReflectionUtil {
 
 	@Nullable
 	public static ItemStack invokeGetSilkTouchDrop(@Nonnull Block block, IBlockState state) {
-		ItemStack stack = invokeMethod(block, "getSilkTouchDrop", "func_180643_i", new Class[] {IBlockState.class}, state);
+		ItemStack stack = invokeMethod(Block.class, block, "getSilkTouchDrop", "func_180643_i", new Class[] {IBlockState.class}, state);
 		if(stack != null) {
 			return stack;
 		} else {
 			return ItemStack.EMPTY;
+		}
+	}
+
+	/**
+	 * Looks up a class by its name, caches it for further use and returns it.<br>
+	 * If it can't find the class, it will be logged and <tt>null</tt> is returned.
+	 *
+	 * @param className The class name to be searched for
+	 * @return The class found or <tt>null</tt>, if the class is unavailable
+	 */
+	public static Class getClass(String className) {
+		try {
+			return CLASS.computeIfAbsent(className, key -> ReflectionHelper.getClass(Inspirations.class.getClassLoader(), key));
+		} catch(UnableToFindClassException e) {
+			InspirationsRegistry.log.error(e);
+			CLASS.putIfAbsent(className, null); // set cache of class to null if it errors trying to find the class
+			return null;
 		}
 	}
 
@@ -69,40 +91,40 @@ public final class ReflectionUtil {
 	 * @param srgName The name used in an obfuscated environment
 	 * @param <T> The type of the return value. Must be the same as or a superclass of the return type of the method! {@link Object}, if the method is <tt>void</tt>
 	 *
-	 * @return The return value of the method or null, if it fails or the method is <tt>void</tt>
+	 * @return The return value of the method or <tt>null</tt>, if it fails or the method is <tt>void</tt>
 	 */
 	@Nullable
-	private static <T> T invokeMethod(@Nonnull final Object instance, final String mcpName, final String srgName, final Class[] paramTypes, final Object... params) {
-		Method m = METHODS.computeIfAbsent(srgName, key -> ReflectionHelper.findMethod(instance.getClass(), key, mcpName, paramTypes));
-
+	private static <T> T invokeMethod(final Class classToSearch, final Object instance, final String mcpName, final String srgName, final Class[] paramTypes, final Object... params) {
 		try {
+			Method m = METHODS.computeIfAbsent(srgName, key -> ReflectionHelper.findMethod(classToSearch, mcpName, key, paramTypes));
 			return (T) m.invoke(instance, params);
-		} catch(IllegalAccessException | IllegalArgumentException | InvocationTargetException | ClassCastException e) {
+		} catch(IllegalAccessException | IllegalArgumentException | NullPointerException | InvocationTargetException | ClassCastException | UnableToFindMethodException e) {
 			InspirationsRegistry.log.error(e);
+			METHODS.putIfAbsent(srgName, null); // set cache of method to null if it errors trying to find the method in the first place
 			return null;
 		}
 	}
 
 	/**
-	 * Searches the instance for the occurrence of a field either named by its SRG name (obfuscated) or MCP name (development),
-	 * caches the reference for further use and returns the value of the field.<br>
+	 * Searches the class for the occurrence of a field either named by its SRG name (obfuscated) or MCP name (development),
+	 * caches the reference for further use and returns the value of the field from the instance (or statically, if the instance is <tt>null</tt>.<br>
 	 * If it can't find the field or something went wrong with getting the value, it will be logged and <tt>null</tt> is returned.
 	 *
-	 * @param instance The instance to be accessed. Cannot be <tt>null</tt>!
+	 * @param instance The instance to be accessed, <tt>null</tt> if the field is static
 	 * @param mcpName The name used in a development environment
 	 * @param srgName The name used in an obfuscated environment
 	 * @param <T> The type of the return value. Must be the same as or a superclass of the type of the field!
 	 *
-	 * @return The value of the field or null, if it fails
+	 * @return The value of the field or <tt>null</tt>, if it fails
 	 */
 	@Nullable
-	private static <T> T getFieldValue(@Nonnull final Object instance, final String mcpName, final String srgName) {
-		Field f = FIELDS.computeIfAbsent(srgName, key -> ReflectionHelper.findField(instance.getClass(), key, mcpName));
-
+	private static <T> T getFieldValue(final Class classToSearch, final Object instance, final String mcpName, final String srgName) {
 		try {
-			return (T) f.get(instance);
-		} catch(IllegalAccessException | ClassCastException e) {
+			Field f = FIELDS.computeIfAbsent(srgName, key -> ReflectionHelper.findField(classToSearch, key, mcpName));
+			return f != null ? (T) f.get(instance) : null;
+		} catch(IllegalAccessException | ClassCastException | NullPointerException | UnableToFindFieldException e) {
 			InspirationsRegistry.log.error(e);
+			FIELDS.putIfAbsent(srgName, null); // set cache of field to null if it errors trying to find the field in the first place
 			return null;
 		}
 	}

--- a/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
+++ b/src/main/java/knightminer/inspirations/library/util/ReflectionUtil.java
@@ -1,6 +1,5 @@
 package knightminer.inspirations.library.util;
 
-import knightminer.inspirations.Inspirations;
 import knightminer.inspirations.library.InspirationsRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -68,7 +67,7 @@ public final class ReflectionUtil {
 	 */
 	public static Class getClass(String className) {
 		try {
-			return CLASS.computeIfAbsent(className, key -> ReflectionHelper.getClass(Inspirations.class.getClassLoader(), key));
+			return CLASS.computeIfAbsent(className, key -> ReflectionHelper.getClass(InspirationsRegistry.class.getClassLoader(), key));
 		} catch(UnableToFindClassException e) {
 			InspirationsRegistry.log.error(e);
 			CLASS.putIfAbsent(className, null); // set cache of class to null if it errors trying to find the class

--- a/src/main/java/knightminer/inspirations/recipes/InspirationsRecipes.java
+++ b/src/main/java/knightminer/inspirations/recipes/InspirationsRecipes.java
@@ -18,6 +18,7 @@ import knightminer.inspirations.library.recipe.cauldron.CauldronDyeRecipe;
 import knightminer.inspirations.library.recipe.cauldron.CauldronFluidRecipe;
 import knightminer.inspirations.library.recipe.cauldron.FillCauldronRecipe;
 import knightminer.inspirations.library.util.RecipeUtil;
+import knightminer.inspirations.library.util.ReflectionUtil;
 import knightminer.inspirations.recipes.block.BlockEnhancedCauldron;
 import knightminer.inspirations.recipes.block.BlockSmashingAnvil;
 import knightminer.inspirations.recipes.dispenser.DispenseCauldronRecipe;
@@ -262,8 +263,10 @@ public class InspirationsRecipes extends PulseBase {
 	 */
 	private void registerPostCauldronRecipes() {
 		if(Config.enableCauldronBrewing) {
-			for(PotionHelper.MixPredicate<PotionType> recipe : PotionHelper.POTION_TYPE_CONVERSIONS) {
-				InspirationsRegistry.addCauldronRecipe(new CauldronBrewingRecipe(recipe.input, recipe.reagent, recipe.output));
+			for(Object recipe : PotionHelper.POTION_TYPE_CONVERSIONS) {
+				InspirationsRegistry.addCauldronRecipe(new CauldronBrewingRecipe(ReflectionUtil.getMixPredicateInput(recipe).get(),
+																				 ReflectionUtil.getMixPredicateReagent(recipe),
+																				 ReflectionUtil.getMixPredicateOutput(recipe).get()));
 			}
 			findRecipesFromBrewingRegistry();
 		}

--- a/src/main/java/knightminer/inspirations/recipes/InspirationsRecipes.java
+++ b/src/main/java/knightminer/inspirations/recipes/InspirationsRecipes.java
@@ -264,9 +264,9 @@ public class InspirationsRecipes extends PulseBase {
 	private void registerPostCauldronRecipes() {
 		if(Config.enableCauldronBrewing) {
 			for(Object recipe : PotionHelper.POTION_TYPE_CONVERSIONS) {
-				InspirationsRegistry.addCauldronRecipe(new CauldronBrewingRecipe(ReflectionUtil.getMixPredicateInput(recipe).get(),
+				InspirationsRegistry.addCauldronRecipe(new CauldronBrewingRecipe(ReflectionUtil.getMixPredicateInput(recipe),
 																				 ReflectionUtil.getMixPredicateReagent(recipe),
-																				 ReflectionUtil.getMixPredicateOutput(recipe).get()));
+																				 ReflectionUtil.getMixPredicateOutput(recipe)));
 			}
 			findRecipesFromBrewingRegistry();
 		}

--- a/src/main/java/knightminer/inspirations/recipes/InspirationsRecipes.java
+++ b/src/main/java/knightminer/inspirations/recipes/InspirationsRecipes.java
@@ -264,9 +264,12 @@ public class InspirationsRecipes extends PulseBase {
 	private void registerPostCauldronRecipes() {
 		if(Config.enableCauldronBrewing) {
 			for(Object recipe : PotionHelper.POTION_TYPE_CONVERSIONS) {
-				InspirationsRegistry.addCauldronRecipe(new CauldronBrewingRecipe(ReflectionUtil.getMixPredicateInput(recipe),
-																				 ReflectionUtil.getMixPredicateReagent(recipe),
-																				 ReflectionUtil.getMixPredicateOutput(recipe)));
+				PotionType input = ReflectionUtil.getMixPredicateInput(recipe);
+				Ingredient reagent = ReflectionUtil.getMixPredicateReagent(recipe);
+				PotionType output = ReflectionUtil.getMixPredicateOutput(recipe);
+				if(input != null && reagent != null && output != null) {
+					InspirationsRegistry.addCauldronRecipe(new CauldronBrewingRecipe(input, reagent, output));
+				}
 			}
 			findRecipesFromBrewingRegistry();
 		}

--- a/src/main/java/knightminer/inspirations/tweaks/InspirationsTweaks.java
+++ b/src/main/java/knightminer/inspirations/tweaks/InspirationsTweaks.java
@@ -1,5 +1,6 @@
 package knightminer.inspirations.tweaks;
 
+import java.lang.reflect.Field;
 import java.util.Iterator;
 
 import com.google.common.eventbus.Subscribe;
@@ -8,6 +9,7 @@ import knightminer.inspirations.common.CommonProxy;
 import knightminer.inspirations.common.Config;
 import knightminer.inspirations.common.PulseBase;
 import knightminer.inspirations.library.InspirationsRegistry;
+import knightminer.inspirations.library.util.ReflectionUtil;
 import knightminer.inspirations.shared.InspirationsShared;
 import knightminer.inspirations.tweaks.block.BlockBetterFlowerPot;
 import knightminer.inspirations.tweaks.block.BlockCactusCrop;
@@ -33,7 +35,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.potion.PotionHelper;
-import net.minecraft.potion.PotionHelper.MixPredicate;
 import net.minecraft.potion.PotionType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
@@ -174,10 +175,10 @@ public class InspirationsTweaks extends PulseBase {
 		}
 		if(Config.brewMissingPotions) {
 			// we need to start by removing a couple vanilla ones which we override
-			Iterator<MixPredicate<PotionType>> iterator = PotionHelper.POTION_TYPE_CONVERSIONS.iterator();
+			Iterator<?> iterator = PotionHelper.POTION_TYPE_CONVERSIONS.iterator();
 			while(iterator.hasNext()) {
-				MixPredicate<PotionType> mix = iterator.next();
-				if(mix.input == PotionTypes.LEAPING || mix.input == PotionTypes.LONG_LEAPING) {
+				PotionType input = ReflectionUtil.getMixPredicateInput(iterator.next()).get();
+				if(input == PotionTypes.LEAPING || input == PotionTypes.LONG_LEAPING) {
 					iterator.remove();
 				}
 			}

--- a/src/main/java/knightminer/inspirations/tweaks/InspirationsTweaks.java
+++ b/src/main/java/knightminer/inspirations/tweaks/InspirationsTweaks.java
@@ -177,7 +177,7 @@ public class InspirationsTweaks extends PulseBase {
 			// we need to start by removing a couple vanilla ones which we override
 			Iterator<?> iterator = PotionHelper.POTION_TYPE_CONVERSIONS.iterator();
 			while(iterator.hasNext()) {
-				PotionType input = ReflectionUtil.getMixPredicateInput(iterator.next()).get();
+				PotionType input = ReflectionUtil.getMixPredicateInput(iterator.next());
 				if(input == PotionTypes.LEAPING || input == PotionTypes.LONG_LEAPING) {
 					iterator.remove();
 				}

--- a/src/main/resources/META-INF/inspirations_at.cfg
+++ b/src/main/resources/META-INF/inspirations_at.cfg
@@ -1,11 +1,7 @@
 # Inspirations -- Access Transformer
 
 # Potions in cauldrons
-public net.minecraft.potion.PotionHelper$MixPredicate # MixPredicate
 public net.minecraft.potion.PotionHelper field_185213_a # POTION_TYPE_CONVERSIONS
-public net.minecraft.potion.PotionHelper$MixPredicate field_185198_a # input
-public net.minecraft.potion.PotionHelper$MixPredicate field_185199_b # reagent
-public net.minecraft.potion.PotionHelper$MixPredicate field_185200_c # output
 
 # Cauldron dye recipes
 public net.minecraft.item.EnumDyeColor field_193351_w # colorValue

--- a/src/main/resources/META-INF/inspirations_at.cfg
+++ b/src/main/resources/META-INF/inspirations_at.cfg
@@ -2,9 +2,6 @@
 
 # Potions in cauldrons
 public net.minecraft.potion.PotionHelper field_185213_a # POTION_TYPE_CONVERSIONS
-public net.minecraft.potion.PotionHelper$MixPredicate field_185198_a # input
-public net.minecraft.potion.PotionHelper$MixPredicate field_185199_b # reagent
-public net.minecraft.potion.PotionHelper$MixPredicate field_185200_c # output
 
 # Cauldron dye recipes
 public net.minecraft.item.EnumDyeColor field_193351_w # colorValue

--- a/src/main/resources/META-INF/inspirations_at.cfg
+++ b/src/main/resources/META-INF/inspirations_at.cfg
@@ -1,7 +1,11 @@
 # Inspirations -- Access Transformer
 
 # Potions in cauldrons
+public net.minecraft.potion.PotionHelper$MixPredicate # MixPredicate
 public net.minecraft.potion.PotionHelper field_185213_a # POTION_TYPE_CONVERSIONS
+public net.minecraft.potion.PotionHelper$MixPredicate field_185198_a # input
+public net.minecraft.potion.PotionHelper$MixPredicate field_185199_b # reagent
+public net.minecraft.potion.PotionHelper$MixPredicate field_185200_c # output
 
 # Cauldron dye recipes
 public net.minecraft.item.EnumDyeColor field_193351_w # colorValue


### PR DESCRIPTION
Given that I couldn't get the Access Transformer to transform the class PotionHelper$MixPredicate to be public (it is package-private now), I resorted to using reflection. Shouldn't impact performance, as they only get accessed during load and the field references are cached.