### PR TITLE
add inspirations:honey fluid to data tags forge/tags/fluids/honey for…

### DIFF
--- a/src/main/resources/data/forge/tags/fluids/honey.json
+++ b/src/main/resources/data/forge/tags/fluids/honey.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+     "inspirations:honey"
+  ]
+}


### PR DESCRIPTION
For processing fluid recipes, and as shown in F3, this adds the honey fluid to the forge tag for compatibility  

Lower right side

![2021-10-21_14 13 33](https://user-images.githubusercontent.com/621529/138361238-a9a0cc06-9ea5-45ae-bdf7-bf2a73283792.png)

![2021-10-21_14 13 31](https://user-images.githubusercontent.com/621529/138361258-84e05190-eae9-403c-a333-7ea5e68bfe3e.png)


