### PR TITLE
Make fitted carpets rotatable and mirrorable

### DIFF
--- a/src/main/java/knightminer/inspirations/tweaks/block/FittedCarpetBlock.java
+++ b/src/main/java/knightminer/inspirations/tweaks/block/FittedCarpetBlock.java
@@ -1,11 +1,16 @@
 package knightminer.inspirations.tweaks.block;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -100,4 +105,48 @@ public class FittedCarpetBlock extends FlatCarpetBlock {
   public VoxelShape getShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext context) {
     return BOUNDS[getBoundsKey(state)];
   }
+
+  @Override
+  public BlockState rotate(BlockState state, Rotation rotation) {
+    BlockState newState = defaultBlockState();
+
+    if (state.getValue(NORTHWEST)) {
+      newState = switch (rotation) {
+        case CLOCKWISE_90 -> newState.setValue(NORTHEAST, true);
+        case CLOCKWISE_180 -> newState.setValue(SOUTHEAST, true);
+        case COUNTERCLOCKWISE_90 -> newState.setValue(SOUTHWEST, true);
+        case NONE -> newState.setValue(NORTHWEST, true); //identity
+      };
+    }
+
+    if (state.getValue(NORTHEAST)) {
+      newState = switch (rotation) {
+        case CLOCKWISE_90 -> newState.setValue(SOUTHEAST, true);
+        case CLOCKWISE_180 -> newState.setValue(SOUTHWEST, true);
+        case COUNTERCLOCKWISE_90 -> newState.setValue(NORTHWEST, true);
+        case NONE -> newState.setValue(NORTHEAST, true); //identity
+      };
+    }
+
+    if (state.getValue(SOUTHEAST)) {
+      newState = switch (rotation) {
+        case CLOCKWISE_90 -> newState.setValue(SOUTHWEST, true);
+        case CLOCKWISE_180 -> newState.setValue(NORTHWEST, true);
+        case COUNTERCLOCKWISE_90 -> newState.setValue(NORTHEAST, true);
+        case NONE -> newState.setValue(SOUTHEAST, true); //identity
+      };
+    }
+
+    if (state.getValue(SOUTHWEST)) {
+      newState = switch (rotation) {
+        case CLOCKWISE_90 -> newState.setValue(NORTHWEST, true);
+        case CLOCKWISE_180 -> newState.setValue(NORTHEAST, true);
+        case COUNTERCLOCKWISE_90 -> newState.setValue(SOUTHEAST, true);
+        case NONE -> newState.setValue(SOUTHWEST, true); //identity
+      };
+    }
+
+    return newState;
+  }
+
 }

--- a/src/main/java/knightminer/inspirations/tweaks/block/FittedCarpetBlock.java
+++ b/src/main/java/knightminer/inspirations/tweaks/block/FittedCarpetBlock.java
@@ -149,4 +149,27 @@ public class FittedCarpetBlock extends FlatCarpetBlock {
     return newState;
   }
 
+  @Override
+  public BlockState mirror(BlockState state, Mirror mirror) {
+    return switch (mirror.rotation()) {
+      case INVERT_X -> {
+        BlockState newState = defaultBlockState();
+        newState = state.getValue(SOUTHWEST) ? newState.setValue(SOUTHEAST, true): newState;
+        newState = state.getValue(SOUTHEAST) ? newState.setValue(SOUTHWEST, true): newState;
+        newState = state.getValue(NORTHWEST) ? newState.setValue(NORTHEAST, true): newState;
+        newState = state.getValue(NORTHEAST) ? newState.setValue(NORTHWEST, true): newState;
+        yield newState;
+      }
+      case INVERT_Z -> {
+        BlockState newState = defaultBlockState();
+        newState = state.getValue(SOUTHWEST) ? newState.setValue(NORTHWEST, true): newState;
+        newState = state.getValue(SOUTHEAST) ? newState.setValue(NORTHEAST, true): newState;
+        newState = state.getValue(NORTHWEST) ? newState.setValue(SOUTHWEST, true): newState;
+        newState = state.getValue(NORTHEAST) ? newState.setValue(SOUTHEAST, true): newState;
+        yield newState;
+      }
+      default -> state; //identity or unsupported operation
+    };
+  }
+
 }

--- a/src/main/java/knightminer/inspirations/tweaks/block/FittedCarpetBlock.java
+++ b/src/main/java/knightminer/inspirations/tweaks/block/FittedCarpetBlock.java
@@ -108,66 +108,44 @@ public class FittedCarpetBlock extends FlatCarpetBlock {
 
   @Override
   public BlockState rotate(BlockState state, Rotation rotation) {
-    BlockState newState = defaultBlockState();
+    return switch (rotation) {
+      case CLOCKWISE_90 -> defaultBlockState()
+              .setValue(NORTHEAST, state.getValue(NORTHWEST))
+              .setValue(SOUTHEAST, state.getValue(NORTHEAST))
+              .setValue(SOUTHWEST, state.getValue(SOUTHEAST))
+              .setValue(NORTHWEST, state.getValue(SOUTHWEST));
 
-    if (state.getValue(NORTHWEST)) {
-      newState = switch (rotation) {
-        case CLOCKWISE_90 -> newState.setValue(NORTHEAST, true);
-        case CLOCKWISE_180 -> newState.setValue(SOUTHEAST, true);
-        case COUNTERCLOCKWISE_90 -> newState.setValue(SOUTHWEST, true);
-        case NONE -> newState.setValue(NORTHWEST, true); //identity
-      };
-    }
+      case CLOCKWISE_180 -> defaultBlockState()
+              .setValue(SOUTHEAST, state.getValue(NORTHWEST))
+              .setValue(SOUTHWEST, state.getValue(NORTHEAST))
+              .setValue(NORTHWEST, state.getValue(SOUTHEAST))
+              .setValue(NORTHEAST, state.getValue(SOUTHWEST));
 
-    if (state.getValue(NORTHEAST)) {
-      newState = switch (rotation) {
-        case CLOCKWISE_90 -> newState.setValue(SOUTHEAST, true);
-        case CLOCKWISE_180 -> newState.setValue(SOUTHWEST, true);
-        case COUNTERCLOCKWISE_90 -> newState.setValue(NORTHWEST, true);
-        case NONE -> newState.setValue(NORTHEAST, true); //identity
-      };
-    }
+      case COUNTERCLOCKWISE_90 -> defaultBlockState()
+              .setValue(SOUTHWEST, state.getValue(NORTHWEST))
+              .setValue(NORTHWEST, state.getValue(NORTHEAST))
+              .setValue(NORTHEAST, state.getValue(SOUTHEAST))
+              .setValue(SOUTHEAST, state.getValue(SOUTHWEST));
 
-    if (state.getValue(SOUTHEAST)) {
-      newState = switch (rotation) {
-        case CLOCKWISE_90 -> newState.setValue(SOUTHWEST, true);
-        case CLOCKWISE_180 -> newState.setValue(NORTHWEST, true);
-        case COUNTERCLOCKWISE_90 -> newState.setValue(NORTHEAST, true);
-        case NONE -> newState.setValue(SOUTHEAST, true); //identity
-      };
-    }
-
-    if (state.getValue(SOUTHWEST)) {
-      newState = switch (rotation) {
-        case CLOCKWISE_90 -> newState.setValue(NORTHWEST, true);
-        case CLOCKWISE_180 -> newState.setValue(NORTHEAST, true);
-        case COUNTERCLOCKWISE_90 -> newState.setValue(SOUTHEAST, true);
-        case NONE -> newState.setValue(SOUTHWEST, true); //identity
-      };
-    }
-
-    return newState;
+      case NONE -> state; //identity
+    };
   }
 
   @Override
   public BlockState mirror(BlockState state, Mirror mirror) {
     return switch (mirror.rotation()) {
-      case INVERT_X -> {
-        BlockState newState = defaultBlockState();
-        newState = state.getValue(SOUTHWEST) ? newState.setValue(SOUTHEAST, true): newState;
-        newState = state.getValue(SOUTHEAST) ? newState.setValue(SOUTHWEST, true): newState;
-        newState = state.getValue(NORTHWEST) ? newState.setValue(NORTHEAST, true): newState;
-        newState = state.getValue(NORTHEAST) ? newState.setValue(NORTHWEST, true): newState;
-        yield newState;
-      }
-      case INVERT_Z -> {
-        BlockState newState = defaultBlockState();
-        newState = state.getValue(SOUTHWEST) ? newState.setValue(NORTHWEST, true): newState;
-        newState = state.getValue(SOUTHEAST) ? newState.setValue(NORTHEAST, true): newState;
-        newState = state.getValue(NORTHWEST) ? newState.setValue(SOUTHWEST, true): newState;
-        newState = state.getValue(NORTHEAST) ? newState.setValue(SOUTHEAST, true): newState;
-        yield newState;
-      }
+      case INVERT_X -> defaultBlockState()
+              .setValue(SOUTHEAST, state.getValue(SOUTHWEST))
+              .setValue(SOUTHWEST, state.getValue(SOUTHEAST))
+              .setValue(NORTHEAST, state.getValue(NORTHWEST))
+              .setValue(NORTHWEST, state.getValue(NORTHEAST));
+
+      case INVERT_Z -> defaultBlockState()
+              .setValue(NORTHWEST, state.getValue(SOUTHWEST))
+              .setValue(NORTHEAST, state.getValue(SOUTHEAST))
+              .setValue(SOUTHWEST, state.getValue(NORTHWEST))
+              .setValue(SOUTHEAST, state.getValue(NORTHEAST));
+
       default -> state; //identity or unsupported operation
     };
   }


### PR DESCRIPTION
This fixes #248 by making the fitted carpets blockstate properly rotatable and mirrorable.
Basically the bug boils down to not having the needed methods implemented that are usually called by structure gen and schematics (e.g. Create mod) when they place down blocks with suppressed block updates.